### PR TITLE
Add Schema.org metadata to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,69 @@
     <!-- Fathom - beautiful, simple website analytics -->
     <script src="https://cdn.usefathom.com/script.js" data-site="BETINVUJ" defer></script>
     <!-- / Fathom -->
+
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "Event",
+        "additionalType": "ExhibitionEvent",
+        "url": "https://2026.pycon.org.au/",
+        "name": "PyCon AU 2026",
+        "description": "PyCon AU is Australia’s national conference for everyone using the Python programming language and is a must-attend event for hundreds of technologists worldwide.",
+        "startDate": "2025-08-12",
+        "endDate": "2025-08-30",
+        "about": {
+          "@type": "ComputerLanguage",
+          "name": "Python",
+          "url": "https://www.python.org/"
+        },
+        "location": {
+          "@type": "Place",
+          "name": "Sofitel Brisbane Central",
+          "url": "https://www.sofitelbrisbane.com.au/",
+          "address": {
+            "@type": "PostalAddress",
+            "streetAddress": "249 Turbot Street",
+            "addressLocality": "Brisbane City",
+            "postalCode": "4000",
+            "addressRegion": "QLD",
+            "addressCountry": "AU"
+          }
+        },
+        "eventAttendanceMode": "https://schema.org/MixedEventAttendanceMode",
+        "inLanguage": "en-AU",
+        "offers": [
+          {
+            "@type": "Offer",
+            "availability": "https://schema.org/InStock",
+            "url": "https://pretix.eu/pyconau/2026/"
+          }
+        ],
+        "superEvent": {
+          "@type": "EventSeries",
+          "name": "PyCon AU",
+          "url": "https://pycon.org.au/",
+          "organizer": {
+            "@id": "#organization"
+          },
+          "sameAs": "https://www.wikidata.org/wiki/Q134350078"
+        },
+        "organizer": {
+          "@id": "#organization",
+          "@type": "Organization",
+          "name": "PyCon AU",
+          "url": "https://pycon.org.au/",
+          "sameAs": [
+            "https://mastodon.pycon.org.au/@pyconau",
+            "https://bsky.app/profile/pyconau.bsky.social",
+            "https://www.linkedin.com/company/pyconau/"
+          ]
+        },
+        "sameAs": [
+          "https://www.wikidata.org/wiki/Q136290798"
+        ]
+      }
+    </script>
   </head>
   <body>
     


### PR DESCRIPTION
This PR adds Schema.org metadata to the homepage, to allow Google to extract information about the event.

Docs: https://developers.google.com/search/docs/appearance/structured-data/event
Testing: https://search.google.com/test/rich-results