### PR TITLE
Fix ticket card content overflow at narrow lg viewports

### DIFF
--- a/src/components/ConnectSubscribeGetInTouchCards.astro
+++ b/src/components/ConnectSubscribeGetInTouchCards.astro
@@ -70,7 +70,7 @@
     class="fadeInUp bg-lavender text-white rounded-[3.125rem] text-center p-10 flex justify-center"
   >
     <div
-      class="flex flex-col lg:gap-0 gap-10 w-full justify-between h-full"
+      class="flex flex-col lg:gap-0 gap-10 lg:w-[80%] w-full justify-between h-full"
     >
       <div class="space-y-4">
         <h3
@@ -84,7 +84,7 @@
       </div>
       <a
         href="mailto:contact@pycon.org.au"
-        class="underline text-base lg:text-lg font-sans hover:text-lime transition-all duration-300"
+        class="underline text-lg font-sans hover:text-lime transition-all duration-300"
         >contact@pycon.org.au</a
       >
     </div>

--- a/src/components/ConnectSubscribeGetInTouchCards.astro
+++ b/src/components/ConnectSubscribeGetInTouchCards.astro
@@ -70,7 +70,7 @@
     class="fadeInUp bg-lavender text-white rounded-[3.125rem] text-center p-10 flex justify-center"
   >
     <div
-      class="flex flex-col lg:gap-0 gap-10 lg:w-[80%] w-full justify-between h-full"
+      class="flex flex-col lg:gap-0 gap-10 w-full justify-between h-full"
     >
       <div class="space-y-4">
         <h3
@@ -84,7 +84,7 @@
       </div>
       <a
         href="mailto:contact@pycon.org.au"
-        class="underline text-lg font-sans hover:text-lime transition-all duration-300"
+        class="underline text-base lg:text-lg font-sans hover:text-lime transition-all duration-300"
         >contact@pycon.org.au</a
       >
     </div>

--- a/src/pages/tickets.astro
+++ b/src/pages/tickets.astro
@@ -136,10 +136,10 @@ import { TICKETING_URL } from "../constants";
                     ><sup>2</sup> Separate registration required</span
                   >
                 </div>
-                <div class="lg:flex hidden flex-wrap lg:flex-nowrap">
-                  <div class="w-[142px] h-[142px] bg-lime rounded-full"></div>
-                  <div class="w-[142px] h-[142px] bg-lime rounded-full"></div>
-                  <div class="w-[142px] h-[142px] bg-lime rounded-full"></div>
+                <div class="lg:flex hidden">
+                  <div class="w-1/3 aspect-square bg-lime rounded-full"></div>
+                  <div class="w-1/3 aspect-square bg-lime rounded-full"></div>
+                  <div class="w-1/3 aspect-square bg-lime rounded-full"></div>
                 </div>
               </div>
             </div>
@@ -217,9 +217,9 @@ import { TICKETING_URL } from "../constants";
                   >
                 </div>
                 <div class="lg:flex hidden">
-                  <img src="/images/star-big.svg" alt="star" />
-                  <img src="/images/star-big.svg" alt="star" />
-                  <img src="/images/star-big.svg" alt="star" />
+                  <img src="/images/star-big.svg" alt="star" class="w-1/3" />
+                  <img src="/images/star-big.svg" alt="star" class="w-1/3" />
+                  <img src="/images/star-big.svg" alt="star" class="w-1/3" />
                 </div>
               </div>
             </div>

--- a/src/pages/tickets.astro
+++ b/src/pages/tickets.astro
@@ -59,7 +59,7 @@ import { TICKETING_URL } from "../constants";
         <div class="grid lg:grid-cols-2 grid-cols-1 gap-5">
           <div class="fadeInUp bg-[#383838] py-14">
             <div
-              class="lg:w-[426px] w-full lg:px-0 px-5 h-full mx-auto flex flex-col gap-16 justify-between"
+              class="lg:max-w-[426px] w-full lg:px-10 px-5 h-full mx-auto flex flex-col gap-16 justify-between"
             >
               <div class="space-y-10">
                 <div
@@ -146,7 +146,7 @@ import { TICKETING_URL } from "../constants";
           </div>
           <div class="fadeInUp bg-[#383838] py-14">
             <div
-              class="lg:w-[426px] w-full lg:px-0 px-5 h-full mx-auto flex flex-col gap-16 justify-between"
+              class="lg:max-w-[426px] w-full lg:px-10 px-5 h-full mx-auto flex flex-col gap-16 justify-between"
             >
               <div class="space-y-10">
                 <div class="flex flex-col lg:flex-row justify-between">
@@ -242,7 +242,7 @@ import { TICKETING_URL } from "../constants";
         <div class="grid lg:grid-cols-2 grid-cols-1 gap-5">
           <div class="fadeInUp bg-[#383838] py-14">
             <div
-              class="lg:w-[426px] w-full lg:px-0 px-5 h-full mx-auto flex flex-col gap-16 justify-between"
+              class="lg:max-w-[426px] w-full lg:px-10 px-5 h-full mx-auto flex flex-col gap-16 justify-between"
             >
               <div class="space-y-10">
                 <div
@@ -292,7 +292,7 @@ import { TICKETING_URL } from "../constants";
           </div>
           <div class="fadeInUp bg-[#383838] py-14">
             <div
-              class="lg:w-[426px] w-full lg:px-0 px-5 h-full mx-auto flex flex-col gap-16 justify-between"
+              class="lg:max-w-[426px] w-full lg:px-10 px-5 h-full mx-auto flex flex-col gap-16 justify-between"
             >
               <div class="space-y-10">
                 <div


### PR DESCRIPTION
## Before / After (1024px)

### Professional / Enthusiast

| Before | After |
|--------|-------|
| <img width="1024" height="1224" alt="before-tickets" src="https://github.com/user-attachments/assets/a74737a7-503d-424d-a4eb-ecc2331a57b4" /> | <img width="1024" height="1267" alt="after-tickets" src="https://github.com/user-attachments/assets/8dc972ac-1d7a-462d-8058-e0e8e041f0bf" /> |

### Contributor / Student

| Before | After |
|--------|-------|
| <img width="1024" height="900" alt="before-more-tickets" src="https://github.com/user-attachments/assets/12ad6e6e-2213-43a2-993f-3e03987487a2" /> | <img width="1024" height="900" alt="after-more-tickets" src="https://github.com/user-attachments/assets/9c16505a-40f1-46a6-84b4-44c4b0aa34e4" /> |

## Summary

Ticket card content overflows into adjacent cards at viewport widths between 1024px and ~1400px. The inner containers used a fixed `lg:w-[426px]` with no padding, but the cards themselves are only ~403px wide at these widths. Decorative circles also rendered as ovals due to fixed dimensions.

## Changes

- `lg:w-[426px] lg:px-0` → `lg:max-w-[426px] lg:px-10` on all 4 ticket card inner containers
- Decorative circles: fixed `w-[142px] h-[142px]` → `w-1/3 aspect-square`
- Star images: added `w-1/3` to scale within container

## Test plan

- [x] Review responsive layouts before and after at multiple resolutions to check it works as expected