### PR TITLE
Session page sharing, bio link styles, and copy improvements

### DIFF
--- a/src/pages/schedule/[code].astro
+++ b/src/pages/schedule/[code].astro
@@ -21,6 +21,11 @@ export async function getStaticPaths() {
 const { session } = Astro.props;
 const { title, code, start, end, room, track, trackName, type, speakers, sponsor, contentWarning } =
   session.data;
+
+// Canonical session URL for sharing
+const sessionUrl = new URL(`/schedule/${code}`, Astro.site ?? "https://2026.pycon.org.au").toString();
+const shareText = encodeURIComponent(`${title} — PyCon AU 2026`);
+const shareUrl = encodeURIComponent(sessionUrl);
 const { Content } = await session.render();
 
 // Generate OG image path if not a break (uses og output type)
@@ -151,6 +156,79 @@ if (trackData) {
               Schedule
             </a>
           </div>
+
+          {type !== "break" && (
+            <div class="fadeInUp mt-14 pt-10 border-t border-emerald/30">
+              <h2 class="text-xl font-semibold text-charcoal mb-6">Share this session</h2>
+              <div class="flex flex-col lg:flex-row justify-between gap-8">
+                <div class="flex flex-col gap-3">
+                  <a
+                    href={`/graphics/sessions/${code}-social.png`}
+                    download
+                    class="inline-flex items-center gap-2 text-sm font-semibold text-emerald hover:underline"
+                  >
+                    <i class="fa-solid fa-download"></i>
+                    Download Social graphic (1280×780)
+                  </a>
+                  <a
+                    href={`/graphics/sessions/${code}-og.png`}
+                    download
+                    class="inline-flex items-center gap-2 text-sm font-semibold text-emerald hover:underline"
+                  >
+                    <i class="fa-solid fa-download"></i>
+                    Download Open Graph image (1200×630)
+                  </a>
+                  <a
+                    href={`/graphics/sessions/${code}-square.png`}
+                    download
+                    class="inline-flex items-center gap-2 text-sm font-semibold text-emerald hover:underline"
+                  >
+                    <i class="fa-solid fa-download"></i>
+                    Download Square graphic (1200×1200)
+                  </a>
+                </div>
+                <div class="flex flex-col gap-3">
+                  <span class="text-md font-semibold text-charcoal">Tell a friend</span>
+                  <div class="flex items-center gap-4">
+                  <button
+                    id="copy-link-btn"
+                    class="inline-flex items-center gap-2 text-sm font-semibold text-charcoal hover:text-emerald transition-colors cursor-pointer"
+                    aria-label="Copy link to clipboard"
+                  >
+                    <i class="fa-solid fa-link text-2xl"></i>
+                  </button>
+                  <a
+                    href={`https://www.linkedin.com/sharing/share-offsite/?url=${shareUrl}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="inline-flex items-center gap-2 text-sm font-semibold text-charcoal hover:text-emerald transition-colors"
+                    aria-label="Share on LinkedIn"
+                  >
+                    <i class="fa-brands fa-linkedin text-2xl"></i>
+                  </a>
+                  <a
+                    href={`https://bsky.app/intent/compose?text=${shareText}%20${shareUrl}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="inline-flex items-center gap-2 text-sm font-semibold text-charcoal hover:text-emerald transition-colors"
+                    aria-label="Share on Bluesky"
+                  >
+                    <i class="fa-brands fa-bluesky text-2xl"></i>
+                  </a>
+                  <a
+                    href={`https://mastodon.social/share?text=${shareText}%20${shareUrl}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="inline-flex items-center gap-2 text-sm font-semibold text-charcoal hover:text-emerald transition-colors"
+                    aria-label="Share on Mastodon"
+                  >
+                    <i class="fa-brands fa-mastodon text-2xl"></i>
+                  </a>
+                  </div>
+                </div>
+              </div>
+            </div>
+          )}
         </div>
       </div>
     </div>
@@ -159,4 +237,19 @@ if (trackData) {
   <Footer />
 
   <script src="/src/scripts/animations.js"></script>
+  <script is:inline define:vars={{ sessionUrl }}>
+    const btn = document.getElementById("copy-link-btn");
+    if (btn) {
+      btn.addEventListener("click", async () => {
+        await navigator.clipboard.writeText(sessionUrl);
+        const icon = btn.querySelector("i");
+        icon.className = "fa-solid fa-check text-2xl";
+        btn.classList.add("text-emerald");
+        setTimeout(() => {
+          icon.className = "fa-solid fa-link text-2xl";
+          btn.classList.remove("text-emerald");
+        }, 2000);
+      });
+    }
+  </script>
 </Base>

--- a/src/pages/schedule/index.astro
+++ b/src/pages/schedule/index.astro
@@ -50,7 +50,7 @@ const tracks = allTracks.sort((a, b) => {
               <h1 class="text-lime">Schedule</h1>
             </div>
             <p class="text-stone font-sans font-base tracking-[0.01em] leading-normal lg:w-[600px]">
-              The PyCon AU 2026 schedule will be published progressively over time. Expect updates in May as the main program and specialist tracks are published.
+              The PyCon AU 2026 schedule is full of talks from around our community, both locally and abroad!
             </p>
           </div>
         </div>

--- a/src/scripts/animations.js
+++ b/src/scripts/animations.js
@@ -75,15 +75,15 @@ function initReadMore() {
     if (!paragraph) return;
 
     // Temporarily add line-clamp to check if truncation is needed
-    paragraph.classList.add("line-clamp-4");
+    paragraph.classList.add("line-clamp-6");
     const needsTruncation = paragraph.scrollHeight > paragraph.clientHeight;
-    paragraph.classList.remove("line-clamp-4");
+    paragraph.classList.remove("line-clamp-6");
 
     // Only add functionality if content exceeds 4 lines
     if (!needsTruncation) return;
 
     // Add line-clamp class
-    paragraph.classList.add("line-clamp-4");
+    paragraph.classList.add("line-clamp-6");
 
     // Create read more button
     const button = document.createElement("button");
@@ -92,7 +92,7 @@ function initReadMore() {
     button.textContent = "Read more";
 
     button.addEventListener("click", () => {
-      paragraph.classList.remove("line-clamp-4");
+      paragraph.classList.remove("line-clamp-6");
       paragraph.classList.add("line-clamp-none");
       button.remove(); // Remove button after expanding
     });

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -216,7 +216,8 @@ footer ul li a {
   @apply space-y-7;
 }
 
-.rich-text a {
+.rich-text a,
+.read-more a {
   @apply text-violet font-semibold underline;
 }
 .rich-text strong {


### PR DESCRIPTION
## Summary

- Add a **Share this session** section to session pages with:
  - Download links for Social (1280×780), OG (1200×630), and Square (1200×1200) graphics
  - **Tell a friend** social share buttons for LinkedIn, Bluesky, and Mastodon
  - Copy-to-clipboard link button with a checkmark confirmation
- Style links in speaker bios as bold violet underlined (matching rich-text prose)
- Increase speaker bio read-more threshold from 4 to 6 lines
- Update schedule hero text to reflect the published schedule

## Test plan

- [ ] Visit a session page and verify the Share section appears below the Schedule button
- [ ] Test copy-to-clipboard button — icon should swap to a checkmark for 2 seconds
- [ ] Test LinkedIn, Bluesky, and Mastodon share links open correctly
- [ ] Download links for all three graphic types work
- [ ] Speaker bios with links render as bold underlined violet
- [ ] Bios under 6 lines no longer show a Read more button

🤖 Generated with [Claude Code](https://claude.com/claude-code)