### PR TITLE
Render session abstract separately with intro text styling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "alpinejs": "^3.15.0",
         "clsx": "^2.1.1",
         "gsap": "^3.13.0",
+        "marked": "^18.0.4",
         "tailwind-merge": "^3.4.0",
         "tailwindcss": "^4.1.16"
       },
@@ -1203,6 +1204,7 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.1.tgz",
       "integrity": "sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -1242,6 +1244,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1262,6 +1265,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1282,6 +1286,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1302,6 +1307,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1322,6 +1328,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1342,6 +1349,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1362,6 +1370,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1382,6 +1391,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1402,6 +1412,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1422,6 +1433,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1442,6 +1454,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1462,6 +1475,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1482,6 +1496,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3616,6 +3631,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -4038,6 +4054,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
       "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "bin": {
@@ -4493,6 +4510,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -4984,6 +5002,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -5004,6 +5023,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -5047,6 +5067,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -5435,6 +5456,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/marked": {
+      "version": "18.0.4",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.4.tgz",
+      "integrity": "sha512-c/BTaKzg0G6ezQx97DAkYU7k0HM6ys0FqYeKBL6hlBByZwy+ycA1+f0vDdjMHKKeEjdgkx0GOv9Il6D+85cOqA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/mdast-util-definitions": {
@@ -6519,6 +6552,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -6533,6 +6567,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -6605,6 +6640,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -7769,6 +7805,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "alpinejs": "^3.15.0",
     "clsx": "^2.1.1",
     "gsap": "^3.13.0",
+    "marked": "^18.0.4",
     "tailwind-merge": "^3.4.0",
     "tailwindcss": "^4.1.16"
   },

--- a/scripts/schedule_sync.py
+++ b/scripts/schedule_sync.py
@@ -256,10 +256,8 @@ def process_sessions(
         if isinstance(description, dict):
             description = description.get("en", str(description))
 
-        # Combine abstract and description for body
-        body = abstract
-        if description and description != abstract:
-            body = f"{abstract}\n\n{description}"
+        # Abstract goes to frontmatter; description-only content goes to body
+        body = description if description and description != abstract else ""
 
         # Get schedule slot from slots lookup (not from submission directly)
         slot = slots_by_submission.get(code, {})
@@ -307,6 +305,7 @@ def process_sessions(
             "trackName": track_name if track_name else None,
             "type": session_type,
             "speakers": speakers,
+            "abstract": abstract if abstract else None,
             "contentWarning": content_warning,
             "body": body,
             "layout": "layout_1",  # Default layout for graphics generation
@@ -445,6 +444,8 @@ def write_session_file(session: dict, output_dir: Path) -> None:
     # Add optional fields only if present
     if session.get("trackName"):
         frontmatter["trackName"] = session["trackName"]
+    if session.get("abstract"):
+        frontmatter["abstract"] = session["abstract"]
     if session.get("contentWarning"):
         frontmatter["contentWarning"] = session["contentWarning"]
     if session.get("sponsor"):

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -15,6 +15,7 @@ const sessions = defineCollection({
       .default("talk"),
     speakers: z.array(z.string()).default([]),
     sponsor: z.string().optional(),
+    abstract: z.string().optional(),
     contentWarning: z.string().optional(),
     youtubeSlug: z.string().optional(),
     graphicsLayout: z.enum(["left", "right"]).optional(), // Graphics panel layout (left or right)

--- a/src/content/sessions/3CYQGY.md
+++ b/src/content/sessions/3CYQGY.md
@@ -10,12 +10,12 @@ speakers:
 - U7H7LA
 layout: layout_2
 trackName: Main Conference
-graphicsLayout: left
-theme: accent_coral
+abstract: "Every team has at least one go-to person that gets others out of sticky
+  situations!\r\nAre they being recognised for contributions to building a cohesive
+  team, or getting bogged down in work that isn’t part of their job description? Let’s
+  get stuck into the concept of glue work, and how handling it properly can help your
+  team bond."
 ---
-
-Every team has at least one go-to person that gets others out of sticky situations!
-Are they being recognised for contributions to building a cohesive team, or getting bogged down in work that isn’t part of their job description? Let’s get stuck into the concept of glue work, and how handling it properly can help your team bond.
 
 This talk is geared towards anyone who works with other people! 
 It’s a love letter to those engaging in tasks that often go unacknowledged, and an invitation to those who experience lots of focus time and visible credit.

--- a/src/content/sessions/3FQZVE.md
+++ b/src/content/sessions/3FQZVE.md
@@ -11,9 +11,8 @@ speakers:
 - H3PQDH
 - SLEHXC
 layout: layout_2
-graphicsLayout: right
-theme: accent_lavender
+abstract: "Welcome to PyCon AU 2026!\r\nJoin us for a short welcome address followed
+  by our first keynote (to be announced)."
 ---
 
-Welcome to PyCon AU 2026!
-Join us for a short welcome address followed by our first keynote (to be announced).
+

--- a/src/content/sessions/7GHUBT.md
+++ b/src/content/sessions/7GHUBT.md
@@ -10,21 +10,19 @@ speakers:
 - 9MPTPG
 layout: layout_2
 trackName: Platform Engineering
-graphicsLayout: right
-theme: accent_coral
+abstract: "Every day at 2pm, our microservice crashed. Same traffic patterns, same
+  infrastructure, same code - yet the database deadlocked and our SLA burned. Logs
+  showed nothing. Metrics showed capacity. Something we couldn't see was destroying
+  our system.\r\n\r\nThis is a story about unknown-unknowns: the failures you can't
+  predict because you can't observe them. Join us as we retrace how OpenTelemetry
+  exposed what our existing tools hid, guided by the principles of observability (or
+  \"O11y\" as we'll affectionately call it).\r\n\r\nWe'll explore:\r\n- \"The three
+  pillars\" of observability\r\n- OpenTelemetry Tracing with auto- and manual-instrumentation
+  in Python\r\n- High cardinality, high dimensionality, and intelligent sampling\r\
+  \n- Querying and visualising traces to debug production mysteries\r\n\r\nLeave knowing
+  exactly where to start instrumenting your own services—and why you should, before
+  2pm strikes your system."
 ---
-
-Every day at 2pm, our microservice crashed. Same traffic patterns, same infrastructure, same code - yet the database deadlocked and our SLA burned. Logs showed nothing. Metrics showed capacity. Something we couldn't see was destroying our system.
-
-This is a story about unknown-unknowns: the failures you can't predict because you can't observe them. Join us as we retrace how OpenTelemetry exposed what our existing tools hid, guided by the principles of observability (or "O11y" as we'll affectionately call it).
-
-We'll explore:
-- "The three pillars" of observability
-- OpenTelemetry Tracing with auto- and manual-instrumentation in Python
-- High cardinality, high dimensionality, and intelligent sampling
-- Querying and visualising traces to debug production mysteries
-
-Leave knowing exactly where to start instrumenting your own services—and why you should, before 2pm strikes your system.
 
 This talk is designed for Python developers who have relied on logs and metrics for production debugging but haven't yet adopted distributed tracing, as well as SREs who appreciate a good production war story. No prerequisites are required, basic familiarity with Python, HTTP services, and databases is helpful but not required.
 

--- a/src/content/sessions/7JZY3E.md
+++ b/src/content/sessions/7JZY3E.md
@@ -10,20 +10,22 @@ speakers:
 - WGSFFL
 layout: layout_2
 trackName: Platform Engineering
-graphicsLayout: left
-theme: accent_coral
+abstract: "Have you ever wondered what it actually takes to deploy your Python/Django
+  or any application to Kubernetes - and build a platform around it? Or if you already
+  have one, whether you'd build it the same way in 2026?\r\nThis talk introduces Kubernetes
+  as LEGO: building a real platform one block at a time, starting from raw primitives,
+  layering Helm and Kustomize where they genuinely earn their place, and finally writing
+  a custom operator in plain Python using kopf.\r\nAt each step, we ask: Does this
+  next block solve a real problem, or create a new one? You'll leave with a composable
+  mental model and a sharper instinct for when to stop."
 ---
-
-Have you ever wondered what it actually takes to deploy your Python/Django or any application to Kubernetes - and build a platform around it? Or if you already have one, whether you'd build it the same way in 2026?
-This talk introduces Kubernetes as LEGO: building a real platform one block at a time, starting from raw primitives, layering Helm and Kustomize where they genuinely earn their place, and finally writing a custom operator in plain Python using kopf.
-At each step, we ask: Does this next block solve a real problem, or create a new one? You'll leave with a composable mental model and a sharper instinct for when to stop.
 
 Platform engineering has a complexity problem. The default playbook - install everything, abstract it all away - produces platforms that are expensive to operate and painful to debug. This talk is for Python developers who are Kubernetes-curious but find the ecosystem overwhelming, and for engineers already using Kubernetes to visually reflect on and revisit their experience with it.
 
 The talk progresses through three levels, each justified by what the previous one couldn't handle:
 
-–	Level 1 - Raw primitives: Pods, Deployments, Services, ConfigMaps. A grounded walkthrough of what plain Kubernetes already gives you - and how far a Django application gets before any extra tooling is needed.
-–	Level 2 - Helm and Kustomize: Helm for consuming and distributing packages; Kustomize for environment overlays of the apps you own. Where each shines, where they create friction when combined, and the hybrid pattern the industry has converged on.
-–	Level 3 - Python operators with kopf: when the built-in API can't express your domain logic, Custom Resource Definitions (CRDs) let you extend it. kopf maps Kubernetes event handlers to Python decorators - making operator development immediately legible to any Python developer, no Go required.
+- Level 1 - Raw primitives: Pods, Deployments, Services, ConfigMaps. A grounded walkthrough of what plain Kubernetes already gives you - and how far a Django application gets before any extra tooling is needed.
+- Level 2 - Helm and Kustomize: Helm for consuming and distributing packages; Kustomize for environment overlays of the apps you own. Where each shines, where they create friction when combined, and the hybrid pattern the industry has converged on.
+- Level 3 - Python operators with kopf: when the built-in API can't express your domain logic, Custom Resource Definitions (CRDs) let you extend it. kopf maps Kubernetes event handlers to Python decorators - making operator development immediately legible to any Python developer, no Go required.
 
 The through-line is a single question asked at every layer: what problem does this solve that the previous level couldn't? That question is the decision framework attendees take home. No prior Kubernetes experience assumed; familiarity with Python or Django is helpful.

--- a/src/content/sessions/7KE7PU.md
+++ b/src/content/sessions/7KE7PU.md
@@ -10,11 +10,19 @@ speakers:
 - TX8ES3
 layout: layout_2
 trackName: Data & AI
-graphicsLayout: left
-theme: charcoal_lemon
+abstract: AI agents are changing how we build software. They have augmented our 
+  software engineering workflow and challenged us to practice a new discipline, 
+  Agentic Engineering. Central to this emerging discipline is the skill, a 
+  natural language markdown file that bundles workflows, tools, and domain 
+  knowledge into a new unit of work for defining what an agent can do. Adopted 
+  as an open standard across the industry, skills sit above programming 
+  languages, not within them. If you've ever written a runbook, a playbook, or 
+  an SOP, you already understand what a skill encodes. This talk explores what a
+  skill is, how skills compose through context rather than interfaces, and what 
+  breaks when your smallest unit of work is no longer deterministic. It is drawn
+  from real experience building an enterprise architect agent, with practical 
+  examples in Python.
 ---
-
-AI agents are changing how we build software. They have augmented our software engineering workflow and challenged us to practice a new discipline, Agentic Engineering. Central to this emerging discipline is the skill, a natural language markdown file that bundles workflows, tools, and domain knowledge into a new unit of work for defining what an agent can do. Adopted as an open standard across the industry, skills sit above programming languages, not within them. If you've ever written a runbook, a playbook, or an SOP, you already understand what a skill encodes. This talk explores what a skill is, how skills compose through context rather than interfaces, and what breaks when your smallest unit of work is no longer deterministic. It is drawn from real experience building an enterprise architect agent, with practical examples in Python.
 
 We've spent decades perfecting abstractions for code such as functions, classes, modules, services. Each one helped us manage complexity at increasing levels of codebase and team size. But AI agents have bent this model by introducing a new opportunity using natural language.
 

--- a/src/content/sessions/8CA7D3.md
+++ b/src/content/sessions/8CA7D3.md
@@ -10,8 +10,14 @@ speakers:
 - PS8BBH
 layout: layout_2
 trackName: Cybersecurity
-graphicsLayout: right
-theme: accent_lavender
+abstract: In October 2025, Python 3.14 was released and with it t-strings, which
+  promise to help python developers write better, and safer python code. While 
+  on the surface, t-string share a similar name to f-strings and are 
+  instantiated with a similar syntax, the resulting Template type, and the 
+  intended usage and audience there of is not always immediately understood. 
+  This talk explores what they are, how they work, who they are for and how they
+  are core to a python philosophy of using constructs and guardrails to helping 
+  python developers write safer code.
 ---
 
-In October 2025, Python 3.14 was released and with it t-strings, which promise to help python developers write better, and safer python code. While on the surface, t-string share a similar name to f-strings and are instantiated with a similar syntax, the resulting Template type, and the intended usage and audience there of is not always immediately understood. This talk explores what they are, how they work, who they are for and how they are core to a python philosophy of using constructs and guardrails to helping python developers write safer code.
+

--- a/src/content/sessions/8LEEB7.md
+++ b/src/content/sessions/8LEEB7.md
@@ -10,15 +10,31 @@ speakers:
 - 9YWARS
 layout: layout_2
 trackName: Main Conference
-graphicsLayout: right
-theme: accent_violet
+abstract: "Porting a scientific software library from a proprietary language to Python
+  can potentially increase its user base, but the porting process itself can be tedious
+  and error prone, and therefore cries out for automation, such as the use of AI coding
+  agents. At the same time, scientific software libraries must be accurate, performant,
+  easy to use, and easy to maintain. An over-reliance on automated tools can result
+  in the software porting equivalent of AI slop: code that is unreliable and unmaintainable.
+  The application of Research Software Engineering principles to the porting of scientific
+  code can complement AI coding agents in preserving both academic rigour and thorough
+  testing throughout the porting process, resulting in a reliable, well-tested and
+  well-documented library.\r\n\r\nIn 2006, my mathematics PhD project resulted in
+  a highly specialized geometrical toolbox that over the years has been used in diverse
+  scientific and engineering applications. In 2013, at a SciPy conference, one of
+  the attendees asked when the toolbox would be ported to Python.\r\n\r\nOn and off
+  over a period of 20 years, I took that toolbox on a journey from an open source
+  package within a proprietary mathematical software ecosystem to its current state
+  as a polished, production-grade Python library. Firstly, in 2024, motivated by my
+  deepening understanding of the diversity of its applications, I modernized the toolbox
+  itself, including automating the testing of help examples. Next, in 2025, the rapid
+  rise of Large Language Models as coding agents prompted me to undertake the long-delayed
+  Python port. The coding agents did far more than a superficial translation of language
+  syntax to Python. They improved the performance of the code by implementing improved
+  algorithms, they converted the help examples into doctests, they created an automated
+  test harness, they helped me to organize and improve the documentation, and they
+  helped automate the PyPI release process."
 ---
-
-Porting a scientific software library from a proprietary language to Python can potentially increase its user base, but the porting process itself can be tedious and error prone, and therefore cries out for automation, such as the use of AI coding agents. At the same time, scientific software libraries must be accurate, performant, easy to use, and easy to maintain. An over-reliance on automated tools can result in the software porting equivalent of AI slop: code that is unreliable and unmaintainable. The application of Research Software Engineering principles to the porting of scientific code can complement AI coding agents in preserving both academic rigour and thorough testing throughout the porting process, resulting in a reliable, well-tested and well-documented library.
-
-In 2006, my mathematics PhD project resulted in a highly specialized geometrical toolbox that over the years has been used in diverse scientific and engineering applications. In 2013, at a SciPy conference, one of the attendees asked when the toolbox would be ported to Python.
-
-On and off over a period of 20 years, I took that toolbox on a journey from an open source package within a proprietary mathematical software ecosystem to its current state as a polished, production-grade Python library. Firstly, in 2024, motivated by my deepening understanding of the diversity of its applications, I modernized the toolbox itself, including automating the testing of help examples. Next, in 2025, the rapid rise of Large Language Models as coding agents prompted me to undertake the long-delayed Python port. The coding agents did far more than a superficial translation of language syntax to Python. They improved the performance of the code by implementing improved algorithms, they converted the help examples into doctests, they created an automated test harness, they helped me to organize and improve the documentation, and they helped automate the PyPI release process.
 
 This talk presents a case study in transforming specialized high-quality mathematical software from a proprietary interpreter environment to modern Python. It focuses on the application of Research Software Engineering principles to a single-maintainer project, including preserving the integrity of the science while improving usability and maintainability. It covers three stages of the transformation.
 

--- a/src/content/sessions/8PXFQM.md
+++ b/src/content/sessions/8PXFQM.md
@@ -10,11 +10,15 @@ speakers:
 - SKY3HY
 layout: layout_2
 trackName: Research Software Engineering
-graphicsLayout: right
-theme: accent_violet
+abstract: Software is widely used and produced in the course of research. Yet, 
+  published works (e.g. journal papers and conference posters) do not always 
+  cite the software that was essential for the research. Citing software has 
+  numerous benefits, including facilitating the reproducibility and transparency
+  of research, as well as providing attribution and credit for the developers. 
+  This talk will discuss the benefits of citing software, how to cite software 
+  and practical suggestions for how to make your software easier for others to 
+  cite.
 ---
-
-Software is widely used and produced in the course of research. Yet, published works (e.g. journal papers and conference posters) do not always cite the software that was essential for the research. Citing software has numerous benefits, including facilitating the reproducibility and transparency of research, as well as providing attribution and credit for the developers. This talk will discuss the benefits of citing software, how to cite software and practical suggestions for how to make your software easier for others to cite.
 
 This talk will include real examples and practical tips. Topics covered will include:
 

--- a/src/content/sessions/8VSJFM.md
+++ b/src/content/sessions/8VSJFM.md
@@ -10,11 +10,12 @@ speakers:
 - FPL7YF
 layout: layout_2
 trackName: Platform Engineering
-graphicsLayout: right
-theme: accent_coral
+abstract: Before the advent of Cloud Computing, owning all your servers and 
+  keeping them in a server room or a leased datacenter was the norm if not the 
+  only game in town. But despite The Cloud having turned into The Hyperscalers, 
+  owning your platform from the switch plane on up is still available... and it 
+  rocks!
 ---
-
-Before the advent of Cloud Computing, owning all your servers and keeping them in a server room or a leased datacenter was the norm if not the only game in town. But despite The Cloud having turned into The Hyperscalers, owning your platform from the switch plane on up is still available... and it rocks!
 
 I am going to take you on a little tour through a platform stack.
 

--- a/src/content/sessions/97G398.md
+++ b/src/content/sessions/97G398.md
@@ -10,13 +10,14 @@ speakers:
 - 9TC3EG
 layout: layout_2
 trackName: Main Conference
-graphicsLayout: right
-theme: accent_lemon
+abstract: "When dealing with a misbehaving Python program, classic strategies like
+  adding piles of print statements can be unsatisfying. Fortunately, Python gives
+  us many ways of \"looking inside\" a running Python process, getting very rich information
+  instantly.\r\n\r\nWe will look at how we can introspect live Python processes, uncovering
+  what a program is doing, and why it’s doing it. We will also cover pragmatic tips
+  on how to tailor these tools for your own problem’s needs, including when restarting
+  your process isn’t an option!"
 ---
-
-When dealing with a misbehaving Python program, classic strategies like adding piles of print statements can be unsatisfying. Fortunately, Python gives us many ways of "looking inside" a running Python process, getting very rich information instantly.
-
-We will look at how we can introspect live Python processes, uncovering what a program is doing, and why it’s doing it. We will also cover pragmatic tips on how to tailor these tools for your own problem’s needs, including when restarting your process isn’t an option!
 
 Python’s runtime offers many helpful hooks into running programs that we can leverage to inspect our running programs. These hooks are lightweight enough that ad-hoc instrumentation tailored to your problem answer tricky questions. On top of that, robust libraries have been built out to work off of these tools
 

--- a/src/content/sessions/9AK3WS.md
+++ b/src/content/sessions/9AK3WS.md
@@ -11,17 +11,20 @@ speakers:
 - K8YDBG
 layout: layout_2
 trackName: Main Conference
-graphicsLayout: right
-theme: accent_coral
+abstract: "Many teams building AI products focus on parsing new context and editing
+  prompts, without knowing if things are improving. They then learn that even a perfect
+  model won't drive success if the product isn't easy to use, or people abandon it
+  after one attempt. Getting the model right is necessary but on its own isn't sufficient.\r\
+  \n\r\nThis talk is about the measurement gap between a model that performs well
+  in offline evaluation and an AI product that actually benefits users. Using a real-world
+  case study, I'll walk through how we built three layers of measurement that gave
+  us genuine confidence in product decisions and shaped team priorities. \r\n\r\n\
+  These three layers - offline model evaluation, online usage metrics, and qualitative
+  user feedback - don't always agree. I'll share why human judgement is essential
+  to make key decisions when navigating conflicting signals, and how to do this with
+  confidence.\r\n\r\nIf you're building AI products and can't answer \"is this actually
+  getting better?\" - this talk is for you."
 ---
-
-Many teams building AI products focus on parsing new context and editing prompts, without knowing if things are improving. They then learn that even a perfect model won't drive success if the product isn't easy to use, or people abandon it after one attempt. Getting the model right is necessary but on its own isn't sufficient.
-
-This talk is about the measurement gap between a model that performs well in offline evaluation and an AI product that actually benefits users. Using a real-world case study, I'll walk through how we built three layers of measurement that gave us genuine confidence in product decisions and shaped team priorities. 
-
-These three layers - offline model evaluation, online usage metrics, and qualitative user feedback - don't always agree. I'll share why human judgement is essential to make key decisions when navigating conflicting signals, and how to do this with confidence.
-
-If you're building AI products and can't answer "is this actually getting better?" - this talk is for you.
 
 Teams building AI products often have many ideas and iterations — parsing new context, editing prompts — without knowing if things are improving overall, or whether fixing one issue is creating another.
 

--- a/src/content/sessions/9KBBEQ.md
+++ b/src/content/sessions/9KBBEQ.md
@@ -10,13 +10,16 @@ speakers:
 - GRFBNL
 layout: layout_2
 trackName: Main Conference
-graphicsLayout: right
-theme: accent_violet
+abstract: "I'm not joking. In 2025 and 2026 our university rocketry team launched
+  several high-powered 12ft tall competition rockets with a custom Python-based process
+  manager framework that controlled all of their rocket telemetry and ground control
+  systems. We called it the Ground Control Station, or GCS for short. \r\n\r\nI lead
+  the creation of the GCS software to compete at the 2025 International Rocket Engineering
+  Competition (IREC) with the intention of winning the Rocket Telemetry Visualisation
+  Sub-Category. We have our own custom flight computer with it's own custom firmware
+  and LoRa networking setup. So we build our visualisation system from the ground
+  up for reliability, scaleability and deployability. All in our Python process manager"
 ---
-
-I'm not joking. In 2025 and 2026 our university rocketry team launched several high-powered 12ft tall competition rockets with a custom Python-based process manager framework that controlled all of their rocket telemetry and ground control systems. We called it the Ground Control Station, or GCS for short. 
-
-I lead the creation of the GCS software to compete at the 2025 International Rocket Engineering Competition (IREC) with the intention of winning the Rocket Telemetry Visualisation Sub-Category. We have our own custom flight computer with it's own custom firmware and LoRa networking setup. So we build our visualisation system from the ground up for reliability, scaleability and deployability. All in our Python process manager
 
 The GCS, known as SOTERIA, is a computer control system for GSE control, avionics communication, and data visualisation. The core of the GCS is a single computer running Student Researched And Designed (SRAD) software with SRAD LoRa radio hardware peripherals. All OSI layers in our networking stack above the physical protocol are SRAD for use with our Australis (avionics) ecosystem. The software converts raw serial input from physical radio interfaces into human-readable output for efficient system monitoring by the GCS operator and visualisations for observers. We use a WebSocket and a protocol buffer based IPC API to communicate with our GCS services. Our web frontend is fully SRAD aside from industry-standard libraries. The GCS operator can see if any system is performing sub-optimally via alert and warning readouts, so they can make an informed GO/NO-GO call quickly. Spectators and other team members have access to several different views detailing all telemetry from both the GSE and avionics systems
 

--- a/src/content/sessions/9PXVYP.md
+++ b/src/content/sessions/9PXVYP.md
@@ -11,9 +11,8 @@ speakers:
 - H3PQDH
 - SLEHXC
 layout: layout_2
-graphicsLayout: left
-theme: stone_lemon
+abstract: "Welcome to PyCon AU 2026!\r\nJoin us for a short welcome address followed
+  by our third keynote (to be announced)."
 ---
 
-Welcome to PyCon AU 2026!
-Join us for a short welcome address followed by our third keynote (to be announced).
+

--- a/src/content/sessions/A3XLCE.md
+++ b/src/content/sessions/A3XLCE.md
@@ -10,13 +10,15 @@ speakers:
 - EQJWS9
 layout: layout_2
 trackName: Research Software Engineering
-graphicsLayout: right
-theme: accent_violet
+abstract: "I regularly enjoy performance that I absolutely did not earn. That’s because
+  NumPy quietly handles an alarming number of hard problems on my behalf. In this
+  talk, we’ll pop the hood on NumPy and look at what it’s actually doing to make Python
+  fast. We’ll even glance at the source code, gently, and without expecting anyone
+  to be an expert in C. \r\n\r\nThis isn’t a talk about becoming a NumPy wizard or
+  writing “clever” code. It’s about building a better mental model of what NumPy already
+  does for us, so we can stop accidentally getting in its way and continue taking
+  credit for performance we mostly didn’t implement ourselves."
 ---
-
-I regularly enjoy performance that I absolutely did not earn. That’s because NumPy quietly handles an alarming number of hard problems on my behalf. In this talk, we’ll pop the hood on NumPy and look at what it’s actually doing to make Python fast. We’ll even glance at the source code, gently, and without expecting anyone to be an expert in C. 
-
-This isn’t a talk about becoming a NumPy wizard or writing “clever” code. It’s about building a better mental model of what NumPy already does for us, so we can stop accidentally getting in its way and continue taking credit for performance we mostly didn’t implement ourselves.
 
 Python is slow. We all know it. And yet, here we are, running numerical workloads that would make a C programmer nod approvingly. How? NumPy. But not *magic*. NumPy deliberate, well-engineered  NumPy.
 

--- a/src/content/sessions/AJQASH.md
+++ b/src/content/sessions/AJQASH.md
@@ -11,11 +11,11 @@ speakers:
 - 9LDURJ
 layout: layout_2
 trackName: DevRel
-graphicsLayout: left
-theme: accent_coral
+abstract: We invite any conference attendee to this session. You do not need to 
+  have a job title associated to DevRel. Developer Relations is about the 
+  developer community of those who use technology and products, so please join 
+  us in discussions around this subject.
 ---
-
-We invite any conference attendee to this session. You do not need to have a job title associated to DevRel. Developer Relations is about the developer community of those who use technology and products, so please join us in discussions around this subject.
 
 Unconferences are created by the people who show up. We are holding this session in an "open space" format (see the [Open Space]([url](https://devopsdays.org/open-space-format/)) format description borrowed from another series of conferences). 
 

--- a/src/content/sessions/ASSXNF.md
+++ b/src/content/sessions/ASSXNF.md
@@ -10,11 +10,18 @@ speakers:
 - PDH7TL
 layout: layout_2
 trackName: DevRel
-graphicsLayout: right
-theme: accent_coral
+abstract: AI assistants can answer most technical questions in seconds now. So 
+  why would a developer sit through a guided workshop? Because reading an answer
+  and building muscle memory are fundamentally different things. This talk looks
+  at how to design interactive, hands-on developer education that stays relevant
+  and engaging in a world where "just ask the AI" is the default. Drawing on 
+  experience building an open source training platform and creating and 
+  delivering workshops on it, the talk gets into the practical details of 
+  structuring workshop content, giving learners real environments to work in, 
+  keeping them engaged, and using AI behind the scenes to create that content 
+  faster without sacrificing the human judgement that makes it more than just AI
+  slop.
 ---
-
-AI assistants can answer most technical questions in seconds now. So why would a developer sit through a guided workshop? Because reading an answer and building muscle memory are fundamentally different things. This talk looks at how to design interactive, hands-on developer education that stays relevant and engaging in a world where "just ask the AI" is the default. Drawing on experience building an open source training platform and creating and delivering workshops on it, the talk gets into the practical details of structuring workshop content, giving learners real environments to work in, keeping them engaged, and using AI behind the scenes to create that content faster without sacrificing the human judgement that makes it more than just AI slop.
 
 Developer education is at an inflection point. AI coding assistants have made it trivially easy to get a snippet of code or a quick explanation, which means the bar for "worth my time" educational content has never been higher. As developer advocates, we need to rethink what we offer that AI cannot: curated learning journeys, real hands-on environments, and the confidence that comes from having built something yourself.
 

--- a/src/content/sessions/AVCYHU.md
+++ b/src/content/sessions/AVCYHU.md
@@ -10,13 +10,17 @@ speakers:
 - WGQRKJ
 layout: layout_2
 trackName: Main Conference
-graphicsLayout: right
-theme: accent_lemon
+abstract: "You've written some Python code. It works great on your machine. Now you
+  want someone else to use that code. How do you deliver your Python code to someone
+  else so that they can run it? And how do you do that if the person who needs to
+  use your code isn't a Python user themselves?\r\n\r\nIn this talk, you'll learn
+  the options you have for delivering your code to someone else. You'll learn what
+  is involved in configuring a project so that someone else can use it, and when you
+  might want to consider bundling your code as a standalone application. You'll get
+  an overview of some of the tools that can be used to produce a standalone application,
+  and a detailed look at one of those options - Briefcase. Finally, you'll be introduced
+  some of the possibly unexpected benefits of bundling your code as a standalone application."
 ---
-
-You've written some Python code. It works great on your machine. Now you want someone else to use that code. How do you deliver your Python code to someone else so that they can run it? And how do you do that if the person who needs to use your code isn't a Python user themselves?
-
-In this talk, you'll learn the options you have for delivering your code to someone else. You'll learn what is involved in configuring a project so that someone else can use it, and when you might want to consider bundling your code as a standalone application. You'll get an overview of some of the tools that can be used to produce a standalone application, and a detailed look at one of those options - Briefcase. Finally, you'll be introduced some of the possibly unexpected benefits of bundling your code as a standalone application.
 
 There are a wide number of ways to get Python code into the hands of others - some of which are well known, some of which aren't. There is no one "right" solution for every situation, and picking the right solution for the right situation can be complicated.
 

--- a/src/content/sessions/BZ93H7.md
+++ b/src/content/sessions/BZ93H7.md
@@ -10,13 +10,14 @@ speakers:
 - EUXXHR
 layout: layout_2
 trackName: Platform Engineering
-graphicsLayout: left
-theme: accent_coral
+abstract: "Training people (and ponies <3) to problem solve under pressure. A discussion
+  on neurorigidity vs neuroflexibility during emergency response. It will expand on
+  how different kinds of incidents, working styles, experience levels, team structures
+  etc create different needs.\r\n\r\nThe speaker has spent 8 years as an SRE, DBRE
+  and Support Engineer working with major New Zealand and international companies,
+  responding to P1 incidents that affected millions of people. She has also spent
+  20+ years as an amateur trainer of horses."
 ---
-
-Training people (and ponies <3) to problem solve under pressure. A discussion on neurorigidity vs neuroflexibility during emergency response. It will expand on how different kinds of incidents, working styles, experience levels, team structures etc create different needs.
-
-The speaker has spent 8 years as an SRE, DBRE and Support Engineer working with major New Zealand and international companies, responding to P1 incidents that affected millions of people. She has also spent 20+ years as an amateur trainer of horses.
 
 I want to talk about training people to problem solve under pressure - and I'm going to compare and constrast training SREs with training horses. Spoiler alert - its very similar! Many of the tradeoffs are the same.
 

--- a/src/content/sessions/CGG8LN.md
+++ b/src/content/sessions/CGG8LN.md
@@ -10,11 +10,15 @@ speakers:
 - YZGZ9W
 layout: layout_2
 trackName: Education
-graphicsLayout: right
-theme: accent_lime
+abstract: Girls don’t leave STEM once; they leave three times. First, in primary
+  school when “I’m bad at maths” becomes a personality. Second, in high school 
+  when they drop senior tech for “something more cool.” Third, in first‑year 
+  engineering when the boyish culture and difficulty finally wear them down. I’m
+  a mechatronics engineer who is terrified of coding and still somehow convinces
+  girls to give it a chance. By being openly honest about my fear, connecting 
+  code to real hobbies, and normalising failure out loud, I turn anxiety into 
+  curiosity - and keep more girls in the room.
 ---
-
-Girls don’t leave STEM once; they leave three times. First, in primary school when “I’m bad at maths” becomes a personality. Second, in high school when they drop senior tech for “something more cool.” Third, in first‑year engineering when the boyish culture and difficulty finally wear them down. I’m a mechatronics engineer who is terrified of coding and still somehow convinces girls to give it a chance. By being openly honest about my fear, connecting code to real hobbies, and normalising failure out loud, I turn anxiety into curiosity - and keep more girls in the room.
 
 This talk is for Python educators, mentors, and community organisers who care about women in tech but keep watching girls disappear at every stage. I’ll share what I’ve seen as an educator and volunteer across schools and outreach programs: three crucial dropout points for girls - primary school, senior subject choices, and first‑year engineering - and how my “I’m terrified of coding” honesty weirdly helps.
 

--- a/src/content/sessions/CPWUE3.md
+++ b/src/content/sessions/CPWUE3.md
@@ -10,13 +10,11 @@ speakers:
 - GC3M8E
 layout: layout_2
 trackName: Main Conference
-graphicsLayout: left
-theme: accent_lime
+abstract: "The fourth wave of the industrial revolution has been seen by many as a
+  very bad idea. Fortunately we’ll soon all be replaced by sentient machines ruled
+  by tech oligarchs. \r\n\r\nDon't fear, there's some compelling parallels and lessons
+  from good old fashioned organised labour!"
 ---
-
-The fourth wave of the industrial revolution has been seen by many as a very bad idea. Fortunately we’ll soon all be replaced by sentient machines ruled by tech oligarchs. 
-
-Don't fear, there's some compelling parallels and lessons from good old fashioned organised labour!
 
 The new ways of working in our workplaces have many benefits - and many new challenges: burnout, tech debt, remote colleagues, rapid hiring/firing, and changing career trajectories. 
 

--- a/src/content/sessions/CWFAQP.md
+++ b/src/content/sessions/CWFAQP.md
@@ -10,12 +10,20 @@ speakers:
 - PTEC7T
 layout: layout_2
 trackName: DevRel
-graphicsLayout: right
-theme: accent_coral
+abstract: "Developer communities are more than just places to ask questions or share
+  code. They are platforms where careers grow, ideas spark, and real impact happens.
+  In this talk, I’ll draw on my experience building and contributing to global developer
+  programs, including initiatives like GitHub Stars, Twilio Champions, and more to
+  explore what makes a community truly thrive.\r\n\r\nWe’ll dive into how communities
+  across platforms like Discord, Reddit, and Twitch create opportunities for learning,
+  visibility, and connection, whether you’re just starting out or looking to level
+  up. I’ll share practical ways developers can get involved, contribute meaningfully,
+  and turn participation into career growth.\r\n\r\nWe’ll also unpack what separates
+  a good community from a great one, from fostering psychological safety to encouraging
+  collaboration and recognising contributions. Whether you’re a developer, advocate,
+  or community builder, you’ll walk away with actionable insights on how to find your
+  people, grow your presence, and help shape communities that give back as much as
+  they give you."
 ---
 
-Developer communities are more than just places to ask questions or share code. They are platforms where careers grow, ideas spark, and real impact happens. In this talk, I’ll draw on my experience building and contributing to global developer programs, including initiatives like GitHub Stars, Twilio Champions, and more to explore what makes a community truly thrive.
 
-We’ll dive into how communities across platforms like Discord, Reddit, and Twitch create opportunities for learning, visibility, and connection, whether you’re just starting out or looking to level up. I’ll share practical ways developers can get involved, contribute meaningfully, and turn participation into career growth.
-
-We’ll also unpack what separates a good community from a great one, from fostering psychological safety to encouraging collaboration and recognising contributions. Whether you’re a developer, advocate, or community builder, you’ll walk away with actionable insights on how to find your people, grow your presence, and help shape communities that give back as much as they give you.

--- a/src/content/sessions/FCLJP9.md
+++ b/src/content/sessions/FCLJP9.md
@@ -10,12 +10,12 @@ speakers:
 - ZJPT93
 layout: layout_2
 trackName: Main Conference
-graphicsLayout: right
-theme: stone_emerald
+abstract: "Breathing is something we all do, tens of thousands of times a day, without
+  even thinking. Should be pretty straightforward to animate, right?\r\nTo answer
+  that question, I made an interactive breathing simulator - a blob that 'breathes'
+  like a human - using the Python Arcade library and techniques for modeling human
+  breathing dynamics based on the scientific research.\r\nTurns out there's a lot
+  more to what keeps us alive than first meets the eye."
 ---
-
-Breathing is something we all do, tens of thousands of times a day, without even thinking. Should be pretty straightforward to animate, right?
-To answer that question, I made an interactive breathing simulator - a blob that 'breathes' like a human - using the Python Arcade library and techniques for modeling human breathing dynamics based on the scientific research.
-Turns out there's a lot more to what keeps us alive than first meets the eye.
 
 This talk is for anyone curious about what happens when you try to make software that reflects your own humanity back to you. I'll share my journey from the spark of an idea through to a working, humanlike-breathing simulator—covering how to model an unfamiliar domain using techniques from the scientific literature, and how strategic modularisation helped keep the project (mostly) out of spaghetti-code territory. By the end, you'll have a framework for growing software from nothing, and a new appreciation for the things we do 20,000 times a day without ever noticing.

--- a/src/content/sessions/H33RW8.md
+++ b/src/content/sessions/H33RW8.md
@@ -10,11 +10,14 @@ speakers:
 - WGQRKJ
 layout: layout_2
 trackName: Main Conference
-graphicsLayout: right
-theme: charcoal
+abstract: If you have a Python program, and you want to display information to 
+  the user that is more than text, you're going to need something more complex 
+  than a script with `print()` and `input()` calls. You could build a website - 
+  but is a web browser your best option? Can you write a native GUI application 
+  using Python? And can you use the same GUI on your laptop *and* your phone? 
+  Find out in this hands-on workshop, where you'll be introduced to the BeeWare 
+  suite of tools for building and deploying GUI apps.
 ---
-
-If you have a Python program, and you want to display information to the user that is more than text, you're going to need something more complex than a script with `print()` and `input()` calls. You could build a website - but is a web browser your best option? Can you write a native GUI application using Python? And can you use the same GUI on your laptop *and* your phone? Find out in this hands-on workshop, where you'll be introduced to the BeeWare suite of tools for building and deploying GUI apps.
 
 In this hands-on tutorial, you'll lean how you can use the BeeWare suite of tools to build a graphical user interface for your code, and deploy that code as a desktop app, and as a mobile app - all from a single pure-Python codebase. 
 

--- a/src/content/sessions/HBK7XS.md
+++ b/src/content/sessions/HBK7XS.md
@@ -10,12 +10,24 @@ speakers:
 - XCQ89F
 layout: layout_2
 trackName: Education
-graphicsLayout: left
-theme: accent_lime
+abstract: "When students can use AI to generate code, explain syntax, and accelerate
+  routine development tasks, the challenge for teachers is no longer just how to assess
+  coding. It is how to keep students genuinely engaged, how to value the design, judgment,
+  communication, and reflection that sit around a software project, and how to structure
+  complex project work so that students can succeed rather than stall at the end.
+  In my dashboarding unit, these pressures came together in a large, project-based
+  subject where students had to build a substantial data product over the semester.\r\
+  \n\r\nThis talk shares how I responded by redesigning the unit around a feed-forward
+  assessment model. Instead of relying mainly on post-submission feedback, I broke
+  the project into authentic stages, replaced lectures before each deadline with draft
+  workshops, built in peer evaluation that assessed the quality of students’ critique
+  rather than their peers’ marks, and used a final showcase to make student work visible
+  to the wider cohort. The result was an assessment design that focused less on what
+  students could produce at the last minute and more on how they developed ideas,
+  responded to feedback, collaborated, and improved over time.\r\n\r\nFor educators
+  teaching Python, data science, or project-based computing subjects, this offers
+  a practical way to design assessment for an AI-open classroom without falling back
+  on bans or surveillance."
 ---
 
-When students can use AI to generate code, explain syntax, and accelerate routine development tasks, the challenge for teachers is no longer just how to assess coding. It is how to keep students genuinely engaged, how to value the design, judgment, communication, and reflection that sit around a software project, and how to structure complex project work so that students can succeed rather than stall at the end. In my dashboarding unit, these pressures came together in a large, project-based subject where students had to build a substantial data product over the semester.
 
-This talk shares how I responded by redesigning the unit around a feed-forward assessment model. Instead of relying mainly on post-submission feedback, I broke the project into authentic stages, replaced lectures before each deadline with draft workshops, built in peer evaluation that assessed the quality of students’ critique rather than their peers’ marks, and used a final showcase to make student work visible to the wider cohort. The result was an assessment design that focused less on what students could produce at the last minute and more on how they developed ideas, responded to feedback, collaborated, and improved over time.
-
-For educators teaching Python, data science, or project-based computing subjects, this offers a practical way to design assessment for an AI-open classroom without falling back on bans or surveillance.

--- a/src/content/sessions/HZUCVL.md
+++ b/src/content/sessions/HZUCVL.md
@@ -10,19 +10,14 @@ speakers:
 - WD9KCJ
 layout: layout_2
 trackName: Main Conference
-graphicsLayout: right
-theme: charcoal
+abstract: "_The virtue of being a lazy programmer, understanding lazy evaluation,
+  and understanding lazy imports (3.15)_\r\n\r\nYour boss wants your program to \"\
+  run faster\". But performance can be a tricky thing.\r\nSometimes we can make a
+  choice of _when_ the program will be slow.\r\nThis talk will explore the \"virtue\"\
+  \ of laziness with regards to programmer approach, and lazy evaluation (with generators
+  and `yield`).\r\nBut mainly the talk will focus on the new 3.15 keyword `lazy` and
+  how it can affect module loading times."
 ---
-
-Title: The Virtues of Being Lazy
-Sub title: The virtue of being a lazy programmer, understanding lazy evaluation, and understanding lazy imports (3.15)
-
--------------------------------
-Abstract:
-Your boss wants your program to "run faster". But performance can be a tricky thing.
-Sometimes we can make a choice of _when_ the program will be slow.
-This talk will explore the "virtue" of laziness with regards to programmer approach, and lazy evaluation (with generators and `yield`).
-But mainly the talk will focus on the new 3.15 keyword `lazy` and how it can affect module loading times.
 
 This talk will cover briefly the role of "laziness" in being a programmer. I will then examine the role of laziness in evaluation (generators and `yield`). That will lead us to laziness in imports.
 

--- a/src/content/sessions/J9DDEA.md
+++ b/src/content/sessions/J9DDEA.md
@@ -10,12 +10,17 @@ speakers:
 - QVSHY7
 layout: layout_2
 trackName: Main Conference
-graphicsLayout: left
-theme: stone
+abstract: Python powers the world’s most critical research, yet the software 
+  behind the science often remains hidden and under supported. This talk distils
+  four years of insights from Research Software Engineering Stories to explore 
+  the real world motivators of the people building Australia’s most impactful 
+  research tools. Attendees will be motivated to transition from fragile scripts
+  to sustainable and citable reusable software infrastructure that endure long 
+  after the code is working for a specific use case.
 ---
 
-Python powers the world’s most critical research, yet the software behind the science often remains hidden and under supported. This talk distils four years of insights from Research Software Engineering Stories to explore the real world motivators of the people building Australia’s most impactful research tools. Attendees will be motivated to transition from fragile scripts to sustainable and citable reusable software infrastructure that endure long after the code is working for a specific use case.
-
 As Python continues to dominate the research landscape across fields from radio astronomy to biosecurity. The fundamental challenge has shifted from "how do we code?" to "how do we sustain code?". This presentation deep dives into the real motivators of the people building and sustaining research software by distilling insights from four years of interviews with leading Australian Research Software Engineers. 
+
 By exploring case studies of successful transitions where individual researcher scripts evolved into community validated Python packages like DStools in Astronomy or whereabouts in spatial data we identify the common threads of success. The session highlights technical best practices for high impact software including architectural patterns and modular design for long term maintenance.
+
 Attendees will walk away motivated to transform their Python scripts into tools that other scientists can easily use and cite and all participants are invited to engage with and expand the series. For developers and engineers this talk provides a clearer understanding of the Australian RSE landscape and the career pathways available within research intensive environments. Finally we highlight the various awards and networking opportunities specifically designed to support and professionalise the work of Research Software Engineers in science.

--- a/src/content/sessions/J9UC8X.md
+++ b/src/content/sessions/J9UC8X.md
@@ -10,15 +10,18 @@ speakers:
 - JSXAPB
 layout: layout_2
 trackName: Education
-graphicsLayout: right
-theme: accent_lime
+abstract: "How do you get teenagers to care about what data they share online? How
+  do you teach them how to make a safe password? How do you keep them engaged and
+  maybe even teach them some python along the way?\r\n\r\nThese were the questions
+  I was asking myself when I created the latest cyber security project for our high-school
+  level workshops and it turns out, after a decade of running python workshops, I
+  might know the answers!\r\n\r\nCome along to see how I took a concept that I wanted
+  students to care about, and broke that down into hands-on activities, all designed
+  to get that “aha” moment in the classroom. Not only teaching python but using python
+  to facilitate teaching deeper computer and cyber literacy, by peeking behind the
+  curtain at what bad actors are actually doing, and how you can apply this technique
+  to other topics."
 ---
-
-How do you get teenagers to care about what data they share online? How do you teach them how to make a safe password? How do you keep them engaged and maybe even teach them some python along the way?
-
-These were the questions I was asking myself when I created the latest cyber security project for our high-school level workshops and it turns out, after a decade of running python workshops, I might know the answers!
-
-Come along to see how I took a concept that I wanted students to care about, and broke that down into hands-on activities, all designed to get that “aha” moment in the classroom. Not only teaching python but using python to facilitate teaching deeper computer and cyber literacy, by peeking behind the curtain at what bad actors are actually doing, and how you can apply this technique to other topics.
 
 Getting kids to think critically about their security online is pretty tricky. They get told what they should or shouldn't be doing on social media all the time, but is it really sinking in? 
 

--- a/src/content/sessions/JDERLD.md
+++ b/src/content/sessions/JDERLD.md
@@ -10,71 +10,52 @@ speakers:
 - SNK8RV
 layout: layout_2
 trackName: Data & AI
-graphicsLayout: left
-theme: accent_lemon
+abstract: "AI-assisted screening tools for diabetic retinopathy (DR) are increasingly
+  \r\nbeing considered for deployment within national health systems. In Aotearoa
+  \r\nNew Zealand, the diabetic retinal screening programme serves over 200,000 \r\
+  \npeople, and AI tools — including THEIA, a system prospectively validated \r\n\
+  within the NZ programme — are being evaluated for clinical integration. \r\nPublished
+  clinical trials consistently report strong aggregate diagnostic \r\naccuracy. But
+  aggregate performance metrics can obscure something critical: \r\ndoes the tool
+  perform equally well for *everyone*?\r\n\r\nThis talk presents a simulation-based
+  evaluation framework, built entirely \r\nin Python, that interrogates the equity
+  implications of deploying AI \r\nscreening tools across demographically diverse
+  populations. Māori and Pacific \r\npeoples in New Zealand experience higher rates
+  of both diabetes and diabetic \r\nretinopathy, greater socioeconomic deprivation,
+  and lower screening attendance \r\nthan NZ European populations. If an AI tool performs
+  less accurately for \r\nthese groups — even modestly — deployment at scale could
+  widen existing \r\nhealth disparities rather than close them.\r\n\r\n**The Framework**\r\
+  \n\r\nThe framework generates a synthetic cohort of 10,000 patients calibrated to
+  \r\nthe NZ diabetic screening population, with demographics (ethnicity, age, sex,
+  \r\nNZDep deprivation quintile) and true disease status drawn from published \r\n\
+  epidemiological data. Three AI tool profiles are then simulated: the IDx-DR \r\n\
+  system (from its pivotal trial and a recent meta-analysis) and the \r\nNZ-developed
+  THEIA system. Each tool is evaluated under two scenarios — equal \r\nperformance
+  across subgroups, and differential performance informed by bias \r\npatterns documented
+  in the clinical AI literature.\r\n\r\nPerformance metrics (sensitivity, specificity,
+  PPV, ROC curves) are \r\ndisaggregated by ethnicity, area deprivation (NZDep), and
+  their intersection, \r\nwith statistical testing to identify significant disparities.\r\
+  \n\r\nAll simulation parameters are fully documented with citations in a \r\n`config/parameters.yaml`
+  file, making the framework transparent, reproducible, \r\nand adaptable. The code
+  is structured as three Jupyter notebooks (cohort \r\ngeneration, diagnostic accuracy
+  evaluation, equity analysis) backed by a \r\nclean Python module layer — so anyone
+  can swap in their own AI tool's \r\nperformance data and re-run the analysis for
+  their own health system context.\r\n\r\n**Key Findings**\r\n\r\nEven modest subgroup-level
+  accuracy gaps — easily obscured in aggregate trial \r\nreports — translate into
+  meaningfully worse outcomes for already-disadvantaged \r\npopulations when projected
+  across a national programme. This is not a \r\nhypothetical concern. Studies of
+  AI diagnostic tools in chest radiology, \r\nophthalmology, and dermatology have
+  documented precisely this pattern.\r\n\r\n**Why Python, Why This Matters**\r\n\r\
+  \nPython provides all the tools needed to build rigorous equity evaluations: \r\n\
+  NumPy and Pandas for cohort simulation, SciPy for statistical testing, and \r\n\
+  Matplotlib/Seaborn for disaggregated visualisation. This talk demonstrates \r\n\
+  that pre-deployment equity evaluation doesn't require proprietary software or \r\
+  \nlarge clinical datasets — just well-structured Python and publicly available \r\
+  \nliterature.\r\n\r\nAttendees will leave with: an understanding of why aggregate
+  AI performance \r\nmetrics are insufficient for equitable deployment decisions;
+  a mental model \r\nfor simulation-based pre-deployment evaluation; and an open-source
+  Python \r\nframework (MIT licence) they can adapt to their own context."
 ---
-
-AI-assisted screening tools for diabetic retinopathy (DR) are increasingly 
-being considered for deployment within national health systems. In Aotearoa 
-New Zealand, the diabetic retinal screening programme serves over 200,000 
-people, and AI tools — including THEIA, a system prospectively validated 
-within the NZ programme — are being evaluated for clinical integration. 
-Published clinical trials consistently report strong aggregate diagnostic 
-accuracy. But aggregate performance metrics can obscure something critical: 
-does the tool perform equally well for *everyone*?
-
-This talk presents a simulation-based evaluation framework, built entirely 
-in Python, that interrogates the equity implications of deploying AI 
-screening tools across demographically diverse populations. Māori and Pacific 
-peoples in New Zealand experience higher rates of both diabetes and diabetic 
-retinopathy, greater socioeconomic deprivation, and lower screening attendance 
-than NZ European populations. If an AI tool performs less accurately for 
-these groups — even modestly — deployment at scale could widen existing 
-health disparities rather than close them.
-
-**The Framework**
-
-The framework generates a synthetic cohort of 10,000 patients calibrated to 
-the NZ diabetic screening population, with demographics (ethnicity, age, sex, 
-NZDep deprivation quintile) and true disease status drawn from published 
-epidemiological data. Three AI tool profiles are then simulated: the IDx-DR 
-system (from its pivotal trial and a recent meta-analysis) and the 
-NZ-developed THEIA system. Each tool is evaluated under two scenarios — equal 
-performance across subgroups, and differential performance informed by bias 
-patterns documented in the clinical AI literature.
-
-Performance metrics (sensitivity, specificity, PPV, ROC curves) are 
-disaggregated by ethnicity, area deprivation (NZDep), and their intersection, 
-with statistical testing to identify significant disparities.
-
-All simulation parameters are fully documented with citations in a 
-`config/parameters.yaml` file, making the framework transparent, reproducible, 
-and adaptable. The code is structured as three Jupyter notebooks (cohort 
-generation, diagnostic accuracy evaluation, equity analysis) backed by a 
-clean Python module layer — so anyone can swap in their own AI tool's 
-performance data and re-run the analysis for their own health system context.
-
-**Key Findings**
-
-Even modest subgroup-level accuracy gaps — easily obscured in aggregate trial 
-reports — translate into meaningfully worse outcomes for already-disadvantaged 
-populations when projected across a national programme. This is not a 
-hypothetical concern. Studies of AI diagnostic tools in chest radiology, 
-ophthalmology, and dermatology have documented precisely this pattern.
-
-**Why Python, Why This Matters**
-
-Python provides all the tools needed to build rigorous equity evaluations: 
-NumPy and Pandas for cohort simulation, SciPy for statistical testing, and 
-Matplotlib/Seaborn for disaggregated visualisation. This talk demonstrates 
-that pre-deployment equity evaluation doesn't require proprietary software or 
-large clinical datasets — just well-structured Python and publicly available 
-literature.
-
-Attendees will leave with: an understanding of why aggregate AI performance 
-metrics are insufficient for equitable deployment decisions; a mental model 
-for simulation-based pre-deployment evaluation; and an open-source Python 
-framework (MIT licence) they can adapt to their own context.
 
 This talk is for Python practitioners interested in data science, healthcare, 
 and responsible AI. No clinical background is needed — the focus is on 

--- a/src/content/sessions/JK7XEF.md
+++ b/src/content/sessions/JK7XEF.md
@@ -10,15 +10,15 @@ speakers:
 - UKAHFT
 layout: layout_2
 trackName: Main Conference
-graphicsLayout: right
-theme: accent_violet
+abstract: "Balancing short-term and long-term objectives during software development
+  forms an underpinning tension which often exhibits during code reviews, sprint planning
+  and prioritisation.\r\n\r\nAudiences should attend to see how concepts like modularity,
+  consistent design language and the use of software patterns can be seen as an expression
+  of managing cost and complexity over time, and how this perspective can help bring
+  clarity to processes such as code reviews, sprint planning, prioritisation and effort
+  estimation.\r\n\r\nThis talk comprises an exploration of how to discuss trade-offs
+  during software development, based on technical examples."
 ---
-
-Balancing short-term and long-term objectives during software development forms an underpinning tension which often exhibits during code reviews, sprint planning and prioritisation.
-
-Audiences should attend to see how concepts like modularity, consistent design language and the use of software patterns can be seen as an expression of managing cost and complexity over time, and how this perspective can help bring clarity to processes such as code reviews, sprint planning, prioritisation and effort estimation.
-
-This talk comprises an exploration of how to discuss trade-offs during software development, based on technical examples.
 
 It’s (more or less) obvious why software needs to meet user requirements. It’s also (more or less) obvious why software needs to meet essential security requirements and essential performance requirements. However, there are many other concerns beyond this which may be balanced during software development. For example, consider whether a new feature should use a functional approach or rely heavily on inheritance as a design pattern. There may not seem to be an obvious or objective answer at first.
 

--- a/src/content/sessions/K3B9LZ.md
+++ b/src/content/sessions/K3B9LZ.md
@@ -10,11 +10,14 @@ speakers:
 - GX9AZX
 layout: layout_2
 trackName: Main Conference
-graphicsLayout: right
-theme: accent_emerald
+abstract: Every few years somebody swears the newest tool to magically avoid 
+  needing developers will boot developers out of a job. Yet here we are, still 
+  coding, still shipping. Come along for a quick tour from COBOL’s “English you 
+  can compile” to today’s LLM powered vibe coding agents and see why each wave 
+  of “code without coders” crashed on the same rocks. You’ll leave with a 
+  pocketful of history, a nose for hype, and concrete ways to pair AI helpers 
+  with your hard-won craft instead of handing the keys over.
 ---
-
-Every few years somebody swears the newest tool to magically avoid needing developers will boot developers out of a job. Yet here we are, still coding, still shipping. Come along for a quick tour from COBOL’s “English you can compile” to today’s LLM powered vibe coding agents and see why each wave of “code without coders” crashed on the same rocks. You’ll leave with a pocketful of history, a nose for hype, and concrete ways to pair AI helpers with your hard-won craft instead of handing the keys over.
 
 Software history is riddled with promises that business folk would simply _describe_ what they want and let the machine do the rest. COBOL and BASIC claimed managers would write their own programs. HyperTalk let anyone click-build a HyperCard stack. BPML and UML tried to generate systems straight from diagrams created by managers and experts in meetings. Constraint based rule engines argued that if you just captured every rule, which managers could just write down, then the code would materialise. Low-code platforms repackaged the dream for the web, and now LLM agentic assistants and “natural-language” IDEs are the latest contenders.  
 
@@ -22,9 +25,9 @@ So why do we keep hearing the same pitch? Because messy requirements, tacit know
 
 In this talk I’ll:
 
-• Zip through six decades of attempts to eliminate developers, their bright ideas, brief wins, and spectacular failures.
-• Unpack the recurring traps: expressive ceilings, accidental complexity, maintenance drag, governance headaches.
-• Show how every cycle boosted demand for devs by making it easier to do business rather than development.
-• Hand you dead simple heuristics for sniff testing the big promises, spotting where these tools can help instead of hinder, and how to team up with AI tools without handing over your craft.
+- Zip through six decades of attempts to eliminate developers, their bright ideas, brief wins, and spectacular failures.
+- Unpack the recurring traps: expressive ceilings, accidental complexity, maintenance drag, governance headaches.
+- Show how every cycle boosted demand for devs by making it easier to do business rather than development.
+- Hand you dead simple heuristics for sniff testing the big promises, spotting where these tools can help instead of hinder, and how to team up with AI tools without handing over your craft.
 
 Expect a breezy ride full of war stories, face-palm moments, and a few “hey, that actually worked” surprises.

--- a/src/content/sessions/K3M8AE.md
+++ b/src/content/sessions/K3M8AE.md
@@ -10,16 +10,24 @@ speakers:
 - KND8AG
 layout: layout_2
 trackName: Cybersecurity
-graphicsLayout: left
-theme: accent_lavender
+abstract: "Authentication continues to fail not because users ignore security advice,
+  but because our systems rely on humans managing reusable secrets. Despite password
+  managers and multi-factor authentication, phishing and credential theft remain the
+  most common causes of account compromise.\r\n\r\nThis talk examines why password-based
+  authentication fails at a structural level. We will explore the assumptions passwords
+  make about human behaviour, why those assumptions break down in practice, and why
+  layered controls like MFA often add friction without removing core failure modes.\r\
+  \n\r\nWe will then introduce passkeys as a human-centred redesign of authentication.
+  We will explain what passkeys are, how they work using public-key cryptography,
+  and why removing shared secrets improves security and usability at the same time.\r\
+  \n\r\nUsing two real-world examples, we will show how passkeys succeed where passwords
+  struggle. We will examine phishing attacks that bypass traditional MFA, and explain
+  how passkeys eliminate the need for users to identify real login pages. We will
+  also look at account compromise caused by password reuse, and how passkeys prevent
+  cross-site impact by design.\r\n\r\nAttendees will leave with a clear mental model
+  of how passkeys work, understand the role of biometrics as a local unlock mechanism,
+  and gain practical guidance on how individuals and developers can start using passkeys
+  today through modern, open web standards."
 ---
 
-Authentication continues to fail not because users ignore security advice, but because our systems rely on humans managing reusable secrets. Despite password managers and multi-factor authentication, phishing and credential theft remain the most common causes of account compromise.
 
-This talk examines why password-based authentication fails at a structural level. We will explore the assumptions passwords make about human behaviour, why those assumptions break down in practice, and why layered controls like MFA often add friction without removing core failure modes.
-
-We will then introduce passkeys as a human-centred redesign of authentication. We will explain what passkeys are, how they work using public-key cryptography, and why removing shared secrets improves security and usability at the same time.
-
-Using two real-world examples, we will show how passkeys succeed where passwords struggle. We will examine phishing attacks that bypass traditional MFA, and explain how passkeys eliminate the need for users to identify real login pages. We will also look at account compromise caused by password reuse, and how passkeys prevent cross-site impact by design.
-
-Attendees will leave with a clear mental model of how passkeys work, understand the role of biometrics as a local unlock mechanism, and gain practical guidance on how individuals and developers can start using passkeys today through modern, open web standards.

--- a/src/content/sessions/KFJLUE.md
+++ b/src/content/sessions/KFJLUE.md
@@ -10,15 +10,13 @@ speakers:
 - PAU3DM
 layout: layout_2
 trackName: Cybersecurity
-graphicsLayout: right
-theme: accent_lavender
+abstract: "Sam built a great gateway. Users are authenticated, requests are validated,
+  the front door is solid. Inside the cluster, services trust each other — because
+  they're inside the cluster.\r\n\r\nThen Omen shows up.\r\n\r\nThis talk follows
+  Sam the SRE through a nightly battle against Omen the Evil Hacker — and how SPIFFE
+  and SPIRE finally give every Python service a cryptographic identity it can prove,
+  not just claim."
 ---
-
-Sam built a great gateway. Users are authenticated, requests are validated, the front door is solid. Inside the cluster, services trust each other — because they're inside the cluster.
-
-Then Omen shows up.
-
-This talk follows Sam the SRE through a nightly battle against Omen the Evil Hacker — and how SPIFFE and SPIRE finally give every Python service a cryptographic identity it can prove, not just claim.
 
 We've all built Castle walls. A solid perimeter and user authentication at the gateway, and then implicit trust everywhere inside — because it's inside the walls, right? Only legitimate traffic gets in.
 But "inside the walls" is not an identity. Any service can walk up to any other and say "hey, it's me." And the other service believes it. Because why wouldn't it?

--- a/src/content/sessions/KLTVGF.md
+++ b/src/content/sessions/KLTVGF.md
@@ -10,16 +10,29 @@ speakers:
 - DXQWZN
 layout: layout_2
 trackName: Main Conference
-graphicsLayout: right
-theme: accent_lime
+abstract: "The tech industry is notoriously fixated on solving things. All products
+  are \"solutions\", all problems are fixable, all friction is anti-productive waste
+  that deserves to be eliminated. We've hacked our workflows and our homes and our
+  lives, automated the boring stuff, and Gotten Things Done. Throwing LLMs into the
+  mix has only amped up this rhetoric.\r\n\r\nBut not all friction is waste. Some
+  of the things that we call \"problems\" are doing the necessary work of teaching
+  us something, building our capabilities, and raising important opportunities to
+  ask questions and double-check assumptions. Optimising this type of problem away
+  creates a short-term win, but the longer-term losses are often much harder to see.\r\
+  \n\r\nWe've also taken steps into a landscape where many everyday acts of problem-solving
+  are being delegated to webs of AI \"agents\", who will autonomously \"decide\" which
+  things are problems, solve them on our behalf, and ping us to tell us when they're
+  done. But how often do they create additional problems as they solve others? How
+  well can humans understand and build on the \"solutions\" that emerge? And what
+  does it do to the development and maintenance of human expertise along the way?\r\
+  \n\r\nThis talk digs into why problems, friction, and \"inefficiency\" are our some
+  of our greatest allies, especially with AI in the picture. We'll look at what researchers
+  like Robert and Elizabeth Bjork and Renée Gosline have shown about the importance
+  of friction, discuss how to distinguish problems worth solving from problems worth
+  preserving, and interrogate the reasons why we are compelled to solve certain problems
+  in the first place. You'll leave this talk with ways determine which problems deserve
+  your tools, and which ones deserve your time.\r\n\r\n(With apologies and thanks
+  to Allie Brosh for the title.)"
 ---
 
-The tech industry is notoriously fixated on solving things. All products are "solutions", all problems are fixable, all friction is anti-productive waste that deserves to be eliminated. We've hacked our workflows and our homes and our lives, automated the boring stuff, and Gotten Things Done. Throwing LLMs into the mix has only amped up this rhetoric.
 
-But not all friction is waste. Some of the things that we call "problems" are doing the necessary work of teaching us something, building our capabilities, and raising important opportunities to ask questions and double-check assumptions. Optimising this type of problem away creates a short-term win, but the longer-term losses are often much harder to see.
-
-We've also taken steps into a landscape where many everyday acts of problem-solving are being delegated to webs of AI "agents", who will autonomously "decide" which things are problems, solve them on our behalf, and ping us to tell us when they're done. But how often do they create additional problems as they solve others? How well can humans understand and build on the "solutions" that emerge? And what does it do to the development and maintenance of human expertise along the way?
-
-This talk digs into why problems, friction, and "inefficiency" are our some of our greatest allies, especially with AI in the picture. We'll look at what researchers like Robert and Elizabeth Bjork and Renée Gosline have shown about the importance of friction, discuss how to distinguish problems worth solving from problems worth preserving, and interrogate the reasons why we are compelled to solve certain problems in the first place. You'll leave this talk with ways determine which problems deserve your tools, and which ones deserve your time.
-
-(With apologies and thanks to Allie Brosh for the title.)

--- a/src/content/sessions/KRR377.md
+++ b/src/content/sessions/KRR377.md
@@ -12,11 +12,10 @@ speakers:
 - TGSVJV
 layout: layout_2
 trackName: Education
-graphicsLayout: left
-theme: accent_lime
+abstract: We're thrilled to announce that PyConAU's Education Track will once 
+  again feature a dedicated Student Showcase, giving Australian high school 
+  students the chance to present their Python projects on the conference stage.
 ---
-
-We're thrilled to announce that PyConAU's Education Track will once again feature a dedicated Student Showcase, giving Australian high school students the chance to present their Python projects on the conference stage.
 
 Whether you've built something in a class assignment, a coding club, or just hacking on your own ideas, we want to hear from you. All levels of experience are welcome—from complete beginners to seasoned Python developers.
 

--- a/src/content/sessions/KYA9TU.md
+++ b/src/content/sessions/KYA9TU.md
@@ -10,11 +10,12 @@ speakers:
 - HHH7CS
 layout: layout_2
 trackName: Education
-graphicsLayout: right
-theme: accent_lime
+abstract: With IDEs like VS Code wanting to autocomplete your entire file based 
+  on the first line, how on earth do we write assessment that actually tests the
+  skill of our students, rather than the skills of Claude? This talk will 
+  explore what is being done in schools and universities across QLD, and offer 
+  suggestions for what you can try in your classroom.
 ---
-
-With IDEs like VS Code wanting to autocomplete your entire file based on the first line, how on earth do we write assessment that actually tests the skill of our students, rather than the skills of Claude? This talk will explore what is being done in schools and universities across QLD, and offer suggestions for what you can try in your classroom.
 
 When designing any assessment, we want to ensure it allows students to provide evidence that accurately represents their knowledge, understanding and skills. Ideally, it should also be straightforward to administer and mark! 
 

--- a/src/content/sessions/M9HBCP.md
+++ b/src/content/sessions/M9HBCP.md
@@ -10,13 +10,17 @@ speakers:
 - NWBHL9
 layout: layout_2
 trackName: Education
-graphicsLayout: right
-theme: accent_lime
+abstract: "Have you got neurodivergent kids who you’d like to teach coding to, but
+  don’t know where to start? Finding a coding project that kids will enjoy is challenging
+  enough as it is, but finding one that engages neurodivergent kids can be even harder.
+  \r\nLet’s look at some strategies for designing coding projects for school aged
+  students, and break down the technical, physical and emotional considerations that
+  help neurodiverse students succeed. There are many tools we can incorporate into
+  lessons to foster growth, and all have different pros and cons. Both the technologies
+  we use and the way we teach are important. \r\nBy constructing your projects with
+  intention for a neurodiverse audience, it can make them more accessible and entertaining
+  for everyone, and build skills outside of just programming."
 ---
-
-Have you got neurodivergent kids who you’d like to teach coding to, but don’t know where to start? Finding a coding project that kids will enjoy is challenging enough as it is, but finding one that engages neurodivergent kids can be even harder. 
-Let’s look at some strategies for designing coding projects for school aged students, and break down the technical, physical and emotional considerations that help neurodiverse students succeed. There are many tools we can incorporate into lessons to foster growth, and all have different pros and cons. Both the technologies we use and the way we teach are important. 
-By constructing your projects with intention for a neurodiverse audience, it can make them more accessible and entertaining for everyone, and build skills outside of just programming.
 
 Figuring out engaging coding projects for neurodiverse learners can be very challenging. There are many approaches, tools, and methodologies to consider. In many cases, what works with one neurodiverse person may or may not work with another. 
 

--- a/src/content/sessions/MDSJTA.md
+++ b/src/content/sessions/MDSJTA.md
@@ -10,15 +10,17 @@ speakers:
 - UFVRZL
 layout: layout_2
 trackName: DevRel
-graphicsLayout: right
-theme: accent_coral
+abstract: "Tech demos can make or break a presentation, and sometimes even a company.
+  When they're on a large stage and compressed into a handful of minutes, getting
+  them right is harder than it looks. Especially when the features are coming in hot.\r\
+  \n\r\nIn this talk, I'll share what I've learned building dozens of demos for Microsoft
+  and GitHub keynotes, large product launches, and even a TED talk.\r\n\r\nWe’ll look
+  at how to turn a feature-parade into a coherent narrative, when and how to use smoke
+  and mirrors without losing trust, and how to make a demo land with very different
+  audiences. We'll also cover how to fit a surprising amount into a short window,
+  how to stay flexible when things change at the last minute, and how to balance risk
+  and impact when failure isn't an option."
 ---
-
-Tech demos can make or break a presentation, and sometimes even a company. When they're on a large stage and compressed into a handful of minutes, getting them right is harder than it looks. Especially when the features are coming in hot.
-
-In this talk, I'll share what I've learned building dozens of demos for Microsoft and GitHub keynotes, large product launches, and even a TED talk.
-
-We’ll look at how to turn a feature-parade into a coherent narrative, when and how to use smoke and mirrors without losing trust, and how to make a demo land with very different audiences. We'll also cover how to fit a surprising amount into a short window, how to stay flexible when things change at the last minute, and how to balance risk and impact when failure isn't an option.
 
 Building tech demos that effectively show off features while remaining realistic and compelling is a skill I've learned over several years. Sometimes through failure, sometimes through success. I've built and (not always personally) delivered keynotes to tens of thousands of people and videos for feature releases viewed by hundreds of thousands.
 

--- a/src/content/sessions/NF98VJ.md
+++ b/src/content/sessions/NF98VJ.md
@@ -10,22 +10,24 @@ speakers:
 - GVHZNZ
 layout: layout_2
 trackName: Research Software Engineering
-graphicsLayout: left
-theme: accent_violet
+abstract: "Moving computationally intensive scientific algorithms from desktop applications
+  to cloud-based services presents unique challenges: How do you maintain performance
+  when your code runs on ephemeral serverless infrastructure? How do you process datasets
+  with 40 million points when Lambda functions have memory limits? \r\n\r\n   This
+  talk shares our journey of migrating geological algorithms to a modern Python-based
+  cloud platform. We'll explore the performance optimization techniques that made
+  this possible, achieving 3–10× speedups through profiling-driven optimization across
+  Python, C++, SIMD, GPU acceleration, and cloud-native batch processing. \r\n\r\n\
+  \   This is not a talk about micro-optimizations or clever tricks. It's about building
+  a sustainable performance engineering practice: measure first, optimize second,
+  and automate the guardrails that prevent regression. Whether you're building ML
+  pipelines, scientific simulations, or data processing systems, these principles
+  will help you achieve high performance without sacrificing maintainability. \r\n\
+  \r\nAfter this talk, you will learn how to: \r\n\r\n- Decide when to optimize in
+  Python vs. when to reach for C++ \r\n- Use profiling tools to identify real bottlenecks—not
+  assumed ones \r\n- Apply quality guardrails that catch bugs and prevent performance
+  regressions \r\n- Design compute workloads for cloud-native horizontal scaling"
 ---
-
-Moving computationally intensive scientific algorithms from desktop applications to cloud-based services presents unique challenges: How do you maintain performance when your code runs on ephemeral serverless infrastructure? How do you process datasets with 40 million points when Lambda functions have memory limits? 
-
-   This talk shares our journey of migrating geological algorithms to a modern Python-based cloud platform. We'll explore the performance optimization techniques that made this possible, achieving 3–10× speedups through profiling-driven optimization across Python, C++, SIMD, GPU acceleration, and cloud-native batch processing. 
-
-   This is not a talk about micro-optimizations or clever tricks. It's about building a sustainable performance engineering practice: measure first, optimize second, and automate the guardrails that prevent regression. Whether you're building ML pipelines, scientific simulations, or data processing systems, these principles will help you achieve high performance without sacrificing maintainability. 
-
-After this talk, you will learn how to: 
-
-- Decide when to optimize in Python vs. when to reach for C++ 
-- Use profiling tools to identify real bottlenecks—not assumed ones 
-- Apply quality guardrails that catch bugs and prevent performance regressions 
-- Design compute workloads for cloud-native horizontal scaling
 
 Over the past 18 months, our team has migrated several battle-tested geological algorithms to a cloud-based Python platform. The work touched every layer: from designing high-level cloud-native architecture to low-level optimization and loop vectorization. Along the way, profiling repeatedly surprised us—the bottlenecks were not where we expected. 
 

--- a/src/content/sessions/NF9ZDV.md
+++ b/src/content/sessions/NF9ZDV.md
@@ -10,15 +10,16 @@ speakers:
 - JF8RCR
 layout: layout_2
 trackName: Cybersecurity
-graphicsLayout: right
-theme: accent_lavender
+abstract: "Application security is not getting easier. Despite better tools, more
+  CVEs, and widespread “shift-left” adoption, vulnerabilities continue to scale with
+  system complexity.\r\n\r\nThis talk distils 60 years of application security history—from
+  early networked systems to modern cloud-native and AI-driven stacks—and connects
+  it to what Python developers are facing today. Using real incidents, ecosystem data,
+  and patterns observed across decades, the session explains why AppSec keeps failing
+  in familiar ways and where the industry is heading next.\r\n\r\nThe goal is understanding
+  which problems are structural, which are self-inflicted, and which approaches are
+  finally worth investing in."
 ---
-
-Application security is not getting easier. Despite better tools, more CVEs, and widespread “shift-left” adoption, vulnerabilities continue to scale with system complexity.
-
-This talk distils 60 years of application security history—from early networked systems to modern cloud-native and AI-driven stacks—and connects it to what Python developers are facing today. Using real incidents, ecosystem data, and patterns observed across decades, the session explains why AppSec keeps failing in familiar ways and where the industry is heading next.
-
-The goal is understanding which problems are structural, which are self-inflicted, and which approaches are finally worth investing in.
 
 Based on my keynote delivered at OWASP AppSec Singapore 2025, this talk compresses six decades of application security evolution into actionable lessons for modern Python teams.
 

--- a/src/content/sessions/NGF8XQ.md
+++ b/src/content/sessions/NGF8XQ.md
@@ -10,10 +10,16 @@ speakers:
 - N8RLSM
 layout: layout_2
 trackName: Main Conference
-graphicsLayout: left
-theme: charcoal
+abstract: "At Atlassian, we take accessibility seriously enough that we have entire
+  teams dedicated to it. There are experts on hand to provide feedback on designs,
+  and answer questions about implementation details. There's a team that runs audits
+  of new features before they're launched. It's honestly pretty good.\r\n\r\nBut obviously
+  not everyone has the resources available for this kind of setup. So what can you
+  do instead? I'm going to talk you through a range of tools and processes that we
+  use to improve the accessibility of our products, what each does well, where they
+  fall short, and what they cost to implement. You can then use this information to
+  figure out which solutions best fit your particular situation, and how you can get
+  the best bang for your accessibility buck."
 ---
 
-At Atlassian, we take accessibility seriously enough that we have entire teams dedicated to it. There are experts on hand to provide feedback on designs, and answer questions about implementation details. There's a team that runs audits of new features before they're launched. It's honestly pretty good.
 
-But obviously not everyone has the resources available for this kind of setup. So what can you do instead? I'm going to talk you through a range of tools and processes that we use to improve the accessibility of our products, what each does well, where they fall short, and what they cost to implement. You can then use this information to figure out which solutions best fit your particular situation, and how you can get the best bang for your accessibility buck.

--- a/src/content/sessions/PKSEBP.md
+++ b/src/content/sessions/PKSEBP.md
@@ -8,11 +8,8 @@ track:
 type: plenary
 speakers: []
 layout: layout_2
-graphicsLayout: left
-theme: accent_lavender
+abstract: Like regular talks, but shorter! Anything could happen!
 ---
-
-Like regular talks, but shorter! Anything could happen!
 
 Lightning talks are presented by YOU! Yes you! 🫵
 

--- a/src/content/sessions/PZTFZF.md
+++ b/src/content/sessions/PZTFZF.md
@@ -10,11 +10,15 @@ speakers:
 - UMB3JY
 layout: layout_2
 trackName: Cybersecurity
-graphicsLayout: right
-theme: accent_lavender
+abstract: Privacy regulations around the world impose strict requirements on how
+  organisations handle personal data (such as Australia's Privacy Act, the EU's 
+  GDPR, US's HIPAA & CCPA, etc). Among the hardest to implement in a data 
+  pipeline are protecting sensitive data from breaches, and erasing an 
+  individual's personal data on request.Finding and deleting every copy of 
+  sensitive data is cumbersome, error-prone, and breaks referential integrity. 
+  Meanwhile, sensitive data sitting in plaintext is exposed the moment a breach 
+  occurs.
 ---
-
-Privacy regulations around the world impose strict requirements on how organisations handle personal data (such as Australia's Privacy Act, the EU's GDPR, US's HIPAA & CCPA, etc). Among the hardest to implement in a data pipeline are protecting sensitive data from breaches, and erasing an individual's personal data on request.Finding and deleting every copy of sensitive data is cumbersome, error-prone, and breaks referential integrity. Meanwhile, sensitive data sitting in plaintext is exposed the moment a breach occurs.
 
 This talk introduces a novel data pipeline architecture, enabled by an open-source Python library created by the speaker, to solve this complex compliance requirement in a single action.
 The library implements the crypto-shredding pattern. 
@@ -25,25 +29,3 @@ The library implements the crypto-shredding pattern.
 - Decrypts sensitive data under authorisation for any customer whose key is maintained.
 
 The talk covers the architecture, the cryptographic foundations of the Python library, practical integration into Python pipelines, and data governance framework for encryption key management and rotation, including a live demo of the library.
-
-This talk is for anyone building Python pipelines and/or handling personal data, such as data architects, data engineers, platform engineers, analytics engineers, etc. The talk builds up from the problem to the solution, covering both the why and the how.
-
-1. The problem (5 min)
-- Sensitive data in plaintext stored in the data platform is a breach liability that most data platforms accept by default.
-- Most companies do not have a solution for policy-compliant sensitive data erasure. The conventional approach to run DELETE statements across all tables in multiple layers fails to guarantee completeness, and breaks referential & analytical integrity.
-
-2. The pipeline architecture and crypto-shredding pattern (8 min)
-- Encrypting sensitive data per customer before loading turns data erasure from a data scanning problem into a key management problem. 
-- The architecture: encryption sits between extract and load in the pipeline, keys are stored outside the data platform in a separate key store with separate access controls. 
-- Why this separation matters: access to the data platform alone is not sufficient to decrypt any sensitive data. This architecture enables single-operation erasure, and protects against breaches.
-
-3. The encryption method, and governance framework (5 min)
-- The same values will encrypt into different ciphertext outputs, thereby protecting against pattern-detection to identify known individuals.
-- Deleting the encryption key renders decryption mathematically impossible, fulfilling legal requirements for sensitive data erasure.
-- Analytical sensitive data is generalised to allow for fair use.
-- Key management, rotation, and decryption framework.
-
-4. Live demo and additional architecture guidance (7 min)
-A walkthrough using the open-source Python library created by the speaker: encrypting a DataFrame, inspecting the key store, deleting a customer's key, demonstrating the decryption fail, batch key fetching for pipeline performance, handling managed ingestion tools (Fivetran, Airbyte) where encryption happens post-load. 
-
-5. Q&A (5 min)

--- a/src/content/sessions/Q7LCGQ.md
+++ b/src/content/sessions/Q7LCGQ.md
@@ -10,13 +10,13 @@ speakers:
 - AENJDR
 layout: layout_2
 trackName: Main Conference
-graphicsLayout: left
-theme: accent_lime
+abstract: "_Do you feel that hard drives and USBs aren’t keeping pace with your organisation’s
+  \"AI-first dynamic cloud-based SaaS B2B\" technology strategy?_ \r\n\r\nToday, I
+  present a novel (and potentially ill-advised) alternative: a file-system that uses
+  Slack Emojis as a storage device. We'll dive into how file systems work, how you
+  can use Python to turn Slack Emojis into infinite free file storage, and maybe find
+  out if this was secretly a terrible idea all along."
 ---
-
-_Do you feel that hard drives and USBs aren’t keeping pace with your organisation’s "AI-first dynamic cloud-based SaaS B2B" technology strategy?_ 
-
-Today, I present a novel (and potentially ill-advised) alternative: a file-system that uses Slack Emojis as a storage device. We'll dive into how file systems work, how you can use Python to turn Slack Emojis into infinite free file storage, and maybe find out if this was secretly a terrible idea all along.
 
 File Systems are an integral part of how modern computers work. They organise the bits and bytes on your hard drives and USB drives, turning them into files and folders that your computer can read.
 

--- a/src/content/sessions/QCWMLU.md
+++ b/src/content/sessions/QCWMLU.md
@@ -11,10 +11,10 @@ speakers:
 - YZDUTX
 layout: layout_2
 trackName: Education
-graphicsLayout: right
-theme: accent_lime
+abstract: Python has become a standard for many (although not all) secondary 
+  schools teaching Digital Technologies in Queensland and Australia more 
+  broadly. Yet challenges remain in bridging the gap between technical skills 
+  that schools are expected to teach and the expertise that industry requires.
 ---
-
-Python has become a standard for many (although not all) secondary schools teaching Digital Technologies in Queensland and Australia more broadly. Yet challenges remain in bridging the gap between technical skills that schools are expected to teach and the expertise that industry requires.
 
 This talk is for those who are interested about the future pipeline of home-grown coders. I intend providing a high-level summary of what sorts of skills underpin the senior Digital Solutions syllabus, as well as personal observations in what skills are being valued and those that are likely to be neglected as students enter tertiary pathways or industry.

--- a/src/content/sessions/QNHZNS.md
+++ b/src/content/sessions/QNHZNS.md
@@ -10,10 +10,12 @@ speakers:
 - MJ9KTK
 layout: layout_2
 trackName: Main Conference
-graphicsLayout: right
-theme: accent_lavender
+abstract: Geoscientists love Python and Jupyter Notebooks for prototyping their 
+  ideas. What they often don't like is dealing with containers, CI/CD, version 
+  control and long-term support.  Whether you are just into volcano photos from 
+  New Zealand or received a notebook called final_model_v3_ACTUAL_FINAL.ipynb 
+  and were asked to "just put it on the server" come along to see how Earth 
+  Sciences New Zealand bridges the gap between research and production.
 ---
-
-Geoscientists love Python and Jupyter Notebooks for prototyping their ideas. What they often don't like is dealing with containers, CI/CD, version control and long-term support.  Whether you are just into volcano photos from New Zealand or received a notebook called final_model_v3_ACTUAL_FINAL.ipynb and were asked to "just put it on the server" come along to see how Earth Sciences New Zealand bridges the gap between research and production.
 
 Detecting when volcanoes may erupt or where and when to expect earthquakes, tsunamis, and landslides are hard problems and subject of active research. Increasingly, scientists developing new algorithms for geohazard monitoring are incentivised to not only write research proposals and publish papers but also ensure that their research is not only useful but also usable and used. I will show how we at Earth Sciences New Zealand tackle this problem through T-shaped skills: teach scientists just enough dev-ops and provide them with templates and helper scripts for git, CI/CD, and running their algorithms and data visualisations in containers on local and public cloud infrastructure so they can look after their algorithms themselves. We believe this is the best long-term strategy to harness cutting-edge research in operations.

--- a/src/content/sessions/QRNWPN.md
+++ b/src/content/sessions/QRNWPN.md
@@ -10,17 +10,17 @@ speakers:
 - FQRHB7
 layout: layout_2
 trackName: Platform Engineering
-graphicsLayout: left
-theme: accent_coral
+abstract: "Changes are scary. Changes in production are scarier, especially if you
+  haven’t done them before. Ideally, you’d have pipelines and staging environments,
+  and everything just gets handled automatically.\r\n\r\nUnfortunately, reality isn’t
+  always ideal, and you’re faced with having to “yolo” a change; implementing something
+  without waiting for everything to be perfect.\r\n\r\nThe aviation industry has spent
+  decades operating safely in environments where not everything is known in advance.
+  It relies on shared attitudes, behaviours, and simple checklists to help people
+  make good decisions under pressure.\r\n\r\nIn this talk, I’ll draw on those ideas
+  and apply them to platform engineering, looking at how to recognise when to commit
+  to a change and when it’s safer to abort and try again."
 ---
-
-Changes are scary. Changes in production are scarier, especially if you haven’t done them before. Ideally, you’d have pipelines and staging environments, and everything just gets handled automatically.
-
-Unfortunately, reality isn’t always ideal, and you’re faced with having to “yolo” a change; implementing something without waiting for everything to be perfect.
-
-The aviation industry has spent decades operating safely in environments where not everything is known in advance. It relies on shared attitudes, behaviours, and simple checklists to help people make good decisions under pressure.
-
-In this talk, I’ll draw on those ideas and apply them to platform engineering, looking at how to recognise when to commit to a change and when it’s safer to abort and try again.
 
 This talk is aimed at SREs, Platform Engineers, or anyone who works on a production "thing".
 

--- a/src/content/sessions/QUZ9TS.md
+++ b/src/content/sessions/QUZ9TS.md
@@ -10,13 +10,13 @@ speakers:
 - 8SQRFW
 layout: layout_2
 trackName: Main Conference
-graphicsLayout: right
-theme: stone_emerald
+abstract: "Pull request reviews are often the single biggest bottleneck in software
+  delivery. What takes minutes to write can sit for days waiting for review, killing
+  velocity and frustrating teams.\r\n\r\nThis talk explores why PR queues stall, what
+  we can learn from massive open source projects that have solved this at scale, and
+  the practical techniques, from automation with Python tooling to team process shifts,
+  that can dramatically reduce your time to merge."
 ---
-
-Pull request reviews are often the single biggest bottleneck in software delivery. What takes minutes to write can sit for days waiting for review, killing velocity and frustrating teams.
-
-This talk explores why PR queues stall, what we can learn from massive open source projects that have solved this at scale, and the practical techniques, from automation with Python tooling to team process shifts, that can dramatically reduce your time to merge.
 
 Speed isn't about writing code faster, it's about removing waiting.
 

--- a/src/content/sessions/RQ7STH.md
+++ b/src/content/sessions/RQ7STH.md
@@ -10,13 +10,14 @@ speakers:
 - GMGTSH
 layout: layout_2
 trackName: Main Conference
-graphicsLayout: left
-theme: accent_violet
+abstract: "Python 3.13 was the first Python version released with a free-threaded
+  mode. Although the default interpreter still utilizes the GIL, it provides provisions
+  that enable us to run a free-threaded version of the interpreter with the GIL disabled.
+  \r\n\r\nThrough this talk, we’ll set up and run the free-threaded interpreter, benchmarking
+  it against the GIL-enabled version for various tasks. We'll assess the impact on
+  single-threaded vs multithreaded code and test the performance across CPU-bound
+  and I/O-bound tasks, aiming to identify scenarios where free-threaded Python excels."
 ---
-
-Python 3.13 was the first Python version released with a free-threaded mode. Although the default interpreter still utilizes the GIL, it provides provisions that enable us to run a free-threaded version of the interpreter with the GIL disabled. 
-
-Through this talk, we’ll set up and run the free-threaded interpreter, benchmarking it against the GIL-enabled version for various tasks. We'll assess the impact on single-threaded vs multithreaded code and test the performance across CPU-bound and I/O-bound tasks, aiming to identify scenarios where free-threaded Python excels.
 
 For decades, the Global Interpreter Lock (GIL) has been one of Python’s most debated design choices. It simplified memory management while limiting true parallelism. With Python 3.13, that story begins to change.
 

--- a/src/content/sessions/RQR97D.md
+++ b/src/content/sessions/RQR97D.md
@@ -11,17 +11,22 @@ speakers:
 - TJVGUM
 layout: layout_2
 trackName: Cybersecurity
-graphicsLayout: left
-theme: accent_lavender
+abstract: "In the good ol' days, we worried about individual maintainers becoming
+  overburdened, or ripple effects from surprise deletions in dependency graphs. Now,
+  with the power of AI, we get to worry about these things on a much bigger scale:
+  on repeat, across entire ecosystems!\r\n\r\nAs AI agents outpace humans in code
+  output, we’re entering a delightful time where vibe-coded pull requests are checked
+  in because they \"look right,\" even if they’ve silently re-introduced classes of
+  security vulnerabilities we thought we'd eliminated.\r\n\r\nIn this talk, we’ll
+  look at some delicious data from [suggested redaction during CFP review of the dataset]
+  to see just how big the problem is (so far). We’ll explore AI slopsquatting, DDOSing
+  maintainers through vulnerability reports (valid or superfluous), and whether \"\
+  living at HEAD\" (with its security risks) might be our best security strategy.\r\
+  \n\r\nWe’ll also talk: private forks, dynamic cooldowns, and whether or not that
+  one legend in Nebraska has already left the chat. Come for the existential dread;
+  stay for the practical tips on not letting your dependency graph become (more of)
+  a dumpster fire."
 ---
-
-In the good ol' days, we worried about individual maintainers becoming overburdened, or ripple effects from surprise deletions in dependency graphs. Now, with the power of AI, we get to worry about these things on a much bigger scale: on repeat, across entire ecosystems!
-
-As AI agents outpace humans in code output, we’re entering a delightful time where vibe-coded pull requests are checked in because they "look right," even if they’ve silently re-introduced classes of security vulnerabilities we thought we'd eliminated.
-
-In this talk, we’ll look at some delicious data from [suggested redaction during CFP review of the dataset] to see just how big the problem is (so far). We’ll explore AI slopsquatting, DDOSing maintainers through vulnerability reports (valid or superfluous), and whether "living at HEAD" (with its security risks) might be our best security strategy.
-
-We’ll also talk: private forks, dynamic cooldowns, and whether or not that one legend in Nebraska has already left the chat. Come for the existential dread; stay for the practical tips on not letting your dependency graph become (more of) a dumpster fire.
 
 We are seeing a massive shift in how code is produced and reviewed, and the scale that this is happening at. While having "eyes on the code" forms the foundation of open-source security, a significant portion of those eyes are now LLMs. ("AIs on the code", anyone? 🫠) 
 

--- a/src/content/sessions/S9AR8C.md
+++ b/src/content/sessions/S9AR8C.md
@@ -10,8 +10,12 @@ speakers:
 - SYHVWJ
 layout: layout_2
 trackName: DevRel
-graphicsLayout: right
-theme: accent_coral
+abstract: GenAI, aka LLMs, have thrown a monkey wrench into the role of DevRel. 
+  What does it mean to create educational materials when someone can just ask 
+  their favourite LLM to create a personalised educational adventure for them? 
+  This talk will investigate options for creating interactive coding 
+  environments that are useful for developers aiming to learn a new technique, 
+  technology, or library.
 ---
 
-GenAI, aka LLMs, have thrown a monkey wrench into the role of DevRel. What does it mean to create educational materials when someone can just ask their favourite LLM to create a personalised educational adventure for them? This talk will investigate options for creating interactive coding environments that are useful for developers aiming to learn a new technique, technology, or library.
+

--- a/src/content/sessions/S9CGAD.md
+++ b/src/content/sessions/S9CGAD.md
@@ -10,11 +10,12 @@ speakers:
 - RJBY8Y
 layout: layout_2
 trackName: Main Conference
-graphicsLayout: left
-theme: accent_lemon
+abstract: "`import re`. `from pathlib import Path`. Python's import system is easy
+  to take for granted, and most of the time we don't need to think about how the import
+  statements we write actually work. Sometimes, however, things do go wrong, and knowing
+  where to look for more information can mean the difference between scratching our
+  heads in bafflement and quickly solving whatever problem we're facing."
 ---
-
-`import re`. `from pathlib import Path`. Python's import system is easy to take for granted, and most of the time we don't need to think about how the import statements we write actually work. Sometimes, however, things do go wrong, and knowing where to look for more information can mean the difference between scratching our heads in bafflement and quickly solving whatever problem we're facing.
 
 For a lot of import related problems, the exception and associated traceback tell us everything we need to know to resolve the issue. Other problems can require a deeper investigation. Are we actually importing the module we think we're importing? Is the interpreter even looking in the right place for the modules we expect it to be loading? We've noticed our application is taking ages to start, where is all that time going?
 

--- a/src/content/sessions/SS9FAU.md
+++ b/src/content/sessions/SS9FAU.md
@@ -11,13 +11,13 @@ speakers:
 - WD7XBJ
 layout: layout_2
 trackName: Main Conference
-graphicsLayout: right
-theme: accent_emerald
+abstract: "What does it mean to be productive? If you work in software development
+  that generally means shipping code, or at least changes to code. There’s always
+  been a tension in how to measure the output of a software developer though, and
+  that’s partly due to the at least partially creative nature of the work we do.\r\
+  \n\r\nSo when a tool comes along and promises to make you more productive, how do
+  you assess that?"
 ---
-
-What does it mean to be productive? If you work in software development that generally means shipping code, or at least changes to code. There’s always been a tension in how to measure the output of a software developer though, and that’s partly due to the at least partially creative nature of the work we do.
-
-So when a tool comes along and promises to make you more productive, how do you assess that?
 
 Yes, this is a talk about LLMs. It’s a talk about the effects of LLMs and what they mean for people in the software development industry. We feel like there’s a discussion to be had around what the role of a software developer was, what it is now, and what it could look like in the future.
 

--- a/src/content/sessions/T3ALAS.md
+++ b/src/content/sessions/T3ALAS.md
@@ -10,10 +10,15 @@ speakers:
 - B9EPFA
 layout: layout_2
 trackName: Cybersecurity
-graphicsLayout: right
-theme: accent_lavender
+abstract: "What does a trauma ICU nurse have in common with an Information Security
+  Officer? More than you'd think. This talk charts one nurse's unconventional path
+  into cybersecurity, and the moment she realised the skills she'd spent years building
+  were exactly what the industry needed. Beyond the personal story, it makes the case
+  that the cybersecurity skills shortage won't be solved by fishing in the same pond.
+  The people we need are already out there: in hospitals, in classrooms, in labs.
+  This talk is for leaders who want teams that think differently, for hiring managers
+  ready to consider cross-sector skill sets, and for anyone standing at a career crossroads
+  wondering if security is even for them."
 ---
-
-What does a trauma ICU nurse have in common with an Information Security Officer? More than you'd think. This talk charts one nurse's unconventional path into cybersecurity, and the moment she realised the skills she'd spent years building were exactly what the industry needed. Beyond the personal story, it makes the case that the cybersecurity skills shortage won't be solved by fishing in the same pond. The people we need are already out there: in hospitals, in classrooms, in labs. This talk is for leaders who want teams that think differently, for hiring managers ready to consider cross-sector skill sets, and for anyone standing at a career crossroads wondering if security is even for them.
 
 Trauma ICU nursing delivers intensity, clinical mastery, and constant challenge. It is also hard to let go of outside the hospital walls, and that nagging awareness of imbalance eventually becomes hard to ignore. This talk follows one nurse's honest pivot into information security, and makes the case that the through-line from clinical care to GRC is shorter than it looks. Risk assessments, compliance frameworks, and stakeholder communication are activities nurses do every single shift. The same skills that keep you calm when everything around you is not, that help you make fast decisions with incomplete information and hold difficult conversations with executives and frontline staff alike, turn out to be exactly what good GRC work demands. Beyond the career shift, this talk covers what it means to enter a male-dominated field as a woman today, what family-friendly workplace culture actually looks like in practice, and why reducing external stressors is not a perk but a performance strategy. This talk also makes the broader case that cyber keeps recruiting from the same pipelines while the skills gap widens, and that teachers, nurses, and other professionals are already doing this work under a different name. Attendees will leave with an understanding of the value that non-traditional backgrounds bring to security teams. Whether you are considering a change, or building a team, this talk is for you.

--- a/src/content/sessions/TGQGWT.md
+++ b/src/content/sessions/TGQGWT.md
@@ -11,8 +11,8 @@ speakers:
 - SLEHXC
 - H3PQDH
 layout: layout_2
-graphicsLayout: left
-theme: accent_coral
+abstract: We conclude PyCon AU 2026 together for closing remarks as we reflect 
+  on what was, and look forward to what will be (sprints!)
 ---
 
-We conclude PyCon AU 2026 together for closing remarks as we reflect on what was, and look forward to what will be (sprints!)
+

--- a/src/content/sessions/TYXRSM.md
+++ b/src/content/sessions/TYXRSM.md
@@ -10,11 +10,11 @@ speakers:
 - 8SBWWP
 layout: layout_2
 trackName: Data & AI
-graphicsLayout: right
-theme: accent_lemon
+abstract: "Dictionaries are one of the first tools Python developers reach for: fast,
+  flexible, and easy to use when building something new. But when do they stop being
+  enough? And when it's easy to generate dataclasses and classes, how do you know
+  if that structure is actually useful?"
 ---
-
-Dictionaries are one of the first tools Python developers reach for: fast, flexible, and easy to use when building something new. But when do they stop being enough? And when it's easy to generate dataclasses and classes, how do you know if that structure is actually useful?
 
 I used to reach for dictionaries for everything. New feature? Dict. API response? Dict. LLM call? Dict.
 

--- a/src/content/sessions/U8CRTN.md
+++ b/src/content/sessions/U8CRTN.md
@@ -8,11 +8,8 @@ track:
 type: plenary
 speakers: []
 layout: layout_2
-graphicsLayout: right
-theme: accent_lavender
+abstract: Like regular talks, but shorter! Anything could happen!
 ---
-
-Like regular talks, but shorter! Anything could happen!
 
 Lightning talks are presented by YOU! Yes you! 🫵
 

--- a/src/content/sessions/V9UCGA.md
+++ b/src/content/sessions/V9UCGA.md
@@ -10,11 +10,14 @@ speakers:
 - QAG9KH
 layout: layout_2
 trackName: Platform Engineering
-graphicsLayout: right
-theme: accent_coral
+abstract: SRE is all about simplicity. So why do so many of us have a copy of 
+  The Google Book sitting on our desk? So much of what we build seeks to emulate
+  companies with millions (if not billions) of customers, while we have neither 
+  the scale to justify such effort, nor the runway to still be around when we’re
+  finished. This talk asks - does my medium-sized scale up need Chaos 
+  Engineering, circuit breakers, and a 10 tier severity matrix… or does it need 
+  a spreadsheet?
 ---
-
-SRE is all about simplicity. So why do so many of us have a copy of The Google Book sitting on our desk? So much of what we build seeks to emulate companies with millions (if not billions) of customers, while we have neither the scale to justify such effort, nor the runway to still be around when we’re finished. This talk asks - does my medium-sized scale up need Chaos Engineering, circuit breakers, and a 10 tier severity matrix… or does it need a spreadsheet?
 
 SRE suffers from a rather serious problem. We are a group of people who love working on complicated problems. We want challenges and ways to show what we know about reliability. And when we can’t find them… we create them.
 

--- a/src/content/sessions/VHXDSA.md
+++ b/src/content/sessions/VHXDSA.md
@@ -11,13 +11,23 @@ speakers:
 - 38JMFR
 layout: layout_2
 trackName: Data & AI
-graphicsLayout: left
-theme: accent_lemon
+abstract: "We needed to produce 25 years of gap-free half-hourly weather data in just
+  two days. The output had to be continuous, reproducible, and ready for production
+  use. We achieved that speed by combining domain knowledge, Python, dbt, and AI-assisted
+  coding, with detailed prompting and a few tight loops of refinement rather than
+  a zero-shot approach. In this talk, we’ll show how we used Python, dbt, and the
+  Chronos-2 time-series foundation model to build a practical weather gap-filling
+  pipeline for variables such as temperature, humidity, and wind speed.\r\n\r\nThis
+  talk focuses on a practical Python engineering question: when does a foundation
+  model become a pragmatic shortcut rather than just an impressive demo? We’ll compare
+  our Chronos-based workflow with a more traditional approach using correlations with
+  nearby weather stations, explain why dbt was such a strong backbone for reproducibility
+  and maintainability, and show why that mattered for a pipeline that needed to remain
+  understandable and easy to update. We’ll also show that gap filling is different
+  from ordinary forecasting: because a missing window has data on both sides, future
+  approaches could fill forward from the start of the gap, backward from the end,
+  and meet in the middle."
 ---
-
-We needed to produce 25 years of gap-free half-hourly weather data in just two days. The output had to be continuous, reproducible, and ready for production use. We achieved that speed by combining domain knowledge, Python, dbt, and AI-assisted coding, with detailed prompting and a few tight loops of refinement rather than a zero-shot approach. In this talk, we’ll show how we used Python, dbt, and the Chronos-2 time-series foundation model to build a practical weather gap-filling pipeline for variables such as temperature, humidity, and wind speed.
-
-This talk focuses on a practical Python engineering question: when does a foundation model become a pragmatic shortcut rather than just an impressive demo? We’ll compare our Chronos-based workflow with a more traditional approach using correlations with nearby weather stations, explain why dbt was such a strong backbone for reproducibility and maintainability, and show why that mattered for a pipeline that needed to remain understandable and easy to update. We’ll also show that gap filling is different from ordinary forecasting: because a missing window has data on both sides, future approaches could fill forward from the start of the gap, backward from the end, and meet in the middle.
 
 This talk is for Python users who work with time series, messy data, or production data workflows and want a practical case study rather than a theoretical forecasting talk.
 

--- a/src/content/sessions/VQD3SG.md
+++ b/src/content/sessions/VQD3SG.md
@@ -11,9 +11,8 @@ speakers:
 - H3PQDH
 - SLEHXC
 layout: layout_2
-graphicsLayout: left
-theme: accent_lemon
+abstract: "Welcome to PyCon AU 2026!\r\nJoin us for a short welcome address followed
+  by our second keynote (to be announced)."
 ---
 
-Welcome to PyCon AU 2026!
-Join us for a short welcome address followed by our second keynote (to be announced).
+

--- a/src/content/sessions/VSVXTJ.md
+++ b/src/content/sessions/VSVXTJ.md
@@ -10,18 +10,22 @@ speakers:
 - MDFERU
 layout: layout_2
 trackName: Main Conference
-graphicsLayout: left
-theme: accent_lime
+abstract: "_Golf lessons beginning in month six for Tiger Woods (6)_\r\nCode golf
+  is terrible programming practice AND no one would want to read text written the
+  same way as cryptic crossword clues. Neither makes any sense! But you can learn
+  from both and they tickle one's brain in a way that puzzles often do.\r\n\r\nThe
+  benefit of both Cryptic crossword clues and code golf is that they are motivating
+  ways to learn the rules of a thing. In Cryptic crosswords you essentially learn
+  the rules of cryptic crosswords while also learning a way to look at the English
+  language at its most flexible. Tiger Woods is the name of a golfer but without the
+  capitalisation it can also be used indicate the habitat of a tiger... not normal
+  woods, but the type of woods in which you'd find a tiger!\r\n\r\nLikewise code golf
+  can be a puzzle that helps you to learn the tricks of a language. Do you understand
+  the parsing rules of white space? You will when you want to remove one more character.
+  Do you use the walrus operator? It can save you a whole line!  Come along and learn
+  a bit about code golf and a bit about cryptic crosswords and probably get addicted
+  to one or the other.\r\n\r\n(The answer was _JUNGLE_ by the way)"
 ---
-
-_Golf lessons beginning in month six for Tiger Woods (6)_
-Code golf is terrible programming practice AND no one would want to read text written the same way as cryptic crossword clues. Neither makes any sense! But you can learn from both and they tickle one's brain in a way that puzzles often do.
-
-The benefit of both Cryptic crossword clues and code golf is that they are motivating ways to learn the rules of a thing. In Cryptic crosswords you essentially learn the rules of cryptic crosswords while also learning a way to look at the English language at its most flexible. Tiger Woods is the name of a golfer but without the capitalisation it can also be used indicate the habitat of a tiger... not normal woods, but the type of woods in which you'd find a tiger!
-
-Likewise code golf can be a puzzle that helps you to learn the tricks of a language. Do you understand the parsing rules of white space? You will when you want to remove one more character. Do you use the walrus operator? It can save you a whole line!  Come along and learn a bit about code golf and a bit about cryptic crosswords and probably get addicted to one or the other.
-
-(The answer was _JUNGLE_ by the way)
 
 "But how was anyone supposed to know that?!" is a phrase I hear often when I try to teach the rules of  cryptic crosswords
 

--- a/src/content/sessions/X9MRPY.md
+++ b/src/content/sessions/X9MRPY.md
@@ -10,12 +10,17 @@ speakers:
 - UJYFNX
 layout: layout_2
 trackName: Main Conference
-graphicsLayout: right
-theme: accent_emerald
+abstract: "At the start of 2026 I decided I wanted to build my own Coding Agent. The
+  goal was to build the tool that would let me do the work of a Software Engineer,
+  but without reading the code. It's a Python codebase that I've never read, and I
+  never intend to read. By building it I've learned some things about doing serious
+  engineering, without reading code.\r\n\r\nWith AI we're writing more code than ever,
+  and more and more non-Engineers are involved in building with code. It is increasingly
+  unsustainable for a human to read and review every line of code. Even if we do human
+  review, the volume is so large and the context is totally gone - we can't expect
+  them to do a good job. So how can we feel safe? What techniques do we need to apply?
+  What technologies do we build? How do we Engineer in a world where we no longer
+  read code?"
 ---
-
-At the start of 2026 I decided I wanted to build my own Coding Agent. The goal was to build the tool that would let me do the work of a Software Engineer, but without reading the code. It's a Python codebase that I've never read, and I never intend to read. By building it I've learned some things about doing serious engineering, without reading code.
-
-With AI we're writing more code than ever, and more and more non-Engineers are involved in building with code. It is increasingly unsustainable for a human to read and review every line of code. Even if we do human review, the volume is so large and the context is totally gone - we can't expect them to do a good job. So how can we feel safe? What techniques do we need to apply? What technologies do we build? How do we Engineer in a world where we no longer read code?
 
 In this talk I'll go through our journey of building small low-risk software without human review. I'll talk about my experiments in building software without review, and the systems I'm building. I'll also talk about the systems I'm using in production to drive high quality code and anti-fragility through AI review. Then how I'm thinking about the future of work in Software Engineering, and whether human review will be a part of that.

--- a/src/content/sessions/XQ8VVL.md
+++ b/src/content/sessions/XQ8VVL.md
@@ -10,17 +10,16 @@ speakers:
 - 3N73EX
 layout: layout_2
 trackName: Main Conference
-graphicsLayout: left
-theme: accent_emerald
+abstract: "Do you ever go to a talk and find that the speaker doesn't talk about quite
+  what you expected? Do you ever wish you could tell them, mid-talk, to talk about
+  something else?\r\n\r\nWell, this is your opportunity to guide me through my own
+  talk!\r\n\r\nI'm going to tell you all about FastAPI. Why it's my web framework
+  of choice, what makes it easy to use, develop and test. How it empowers you to focus
+  on the important stuff instead of spending loads of time on boilerplate.\r\n\r\n\
+  There's far too much in one framework to talk about it all in 30 minutes though,
+  so you'll get to vote on which topics I should focus on, which examples should get
+  more detail, and what matters to you."
 ---
-
-Do you ever go to a talk and find that the speaker doesn't talk about quite what you expected? Do you ever wish you could tell them, mid-talk, to talk about something else?
-
-Well, this is your opportunity to guide me through my own talk!
-
-I'm going to tell you all about FastAPI. Why it's my web framework of choice, what makes it easy to use, develop and test. How it empowers you to focus on the important stuff instead of spending loads of time on boilerplate.
-
-There's far too much in one framework to talk about it all in 30 minutes though, so you'll get to vote on which topics I should focus on, which examples should get more detail, and what matters to you.
 
 I've used a lot of web frameworks over the years. First I was a student and used Flask. Then I was a consultant and used Ruby on Rails. After that, I used Django at a startup. In Big Tech I used Java's Spring framework.
 

--- a/src/content/sessions/XWLM8L.md
+++ b/src/content/sessions/XWLM8L.md
@@ -10,17 +10,30 @@ speakers:
 - ALM8CW
 layout: layout_2
 trackName: Data & AI
-graphicsLayout: left
-theme: charcoal_lemon
+abstract: "RAG applications come in many shapes. Some start as simple keyword searches
+  over historical records. Others layer on semantic embeddings, hybrid retrieval (semantic
+  + keyword/lexical searches), reranking, and increasingly sophisticated prompting.
+  But regardless of where your system sits on that spectrum, the question is the same:
+  how do you know it actually works?\r\n\r\nThis talk presents a level-by-level framework
+  for building and evaluating RAG systems in Python, using a real AI-assisted ticket
+  resolution application as the running example. Starting from the simplest possible
+  retrieval setup (lexical matching with BM25 over historical tickets), the talk introduces
+  evaluations early, explains why they matter, and then walks through growing both
+  the RAG application and its eval suite in lockstep through four levels of complexity:
+  lexical retrieval, semantic embedding-based retrieval, hybrid retrieval with log
+  filtering using Drain3, and hybrid retrieval with reranking and context window tuning.
+  At each level, the talk introduces only the evaluation metrics that become necessary
+  at that stage, so the audience builds intuition for which evals matter and when.\r\
+  \n\r\nAlong the way, the talk covers practical topics including how to compose simple
+  metrics like faithfulness, context precision, and recall into an experiment harness
+  for tuning reranking strategies (comparing Weighted RRF, plain RRF, Z-score normalization,
+  and Min-Max normalization), and for detecting context rot. At the end, the talk
+  covers how to avoid common pitfalls in LLM-based evaluation such as positional bias
+  and numerical scoring scales.\r\n\r\nThis talk is for Python developers and data
+  scientists who are building or planning to build reliable & robust RAG applications
+  and want a practical mental model for when to introduce which evaluations as their
+  system grows in complexity."
 ---
-
-RAG applications come in many shapes. Some start as simple keyword searches over historical records. Others layer on semantic embeddings, hybrid retrieval (semantic + keyword/lexical searches), reranking, and increasingly sophisticated prompting. But regardless of where your system sits on that spectrum, the question is the same: how do you know it actually works?
-
-This talk presents a level-by-level framework for building and evaluating RAG systems in Python, using a real AI-assisted ticket resolution application as the running example. Starting from the simplest possible retrieval setup (lexical matching with BM25 over historical tickets), the talk introduces evaluations early, explains why they matter, and then walks through growing both the RAG application and its eval suite in lockstep through four levels of complexity: lexical retrieval, semantic embedding-based retrieval, hybrid retrieval with log filtering using Drain3, and hybrid retrieval with reranking and context window tuning. At each level, the talk introduces only the evaluation metrics that become necessary at that stage, so the audience builds intuition for which evals matter and when.
-
-Along the way, the talk covers practical topics including how to compose simple metrics like faithfulness, context precision, and recall into an experiment harness for tuning reranking strategies (comparing Weighted RRF, plain RRF, Z-score normalization, and Min-Max normalization), and for detecting context rot. At the end, the talk covers how to avoid common pitfalls in LLM-based evaluation such as positional bias and numerical scoring scales.
-
-This talk is for Python developers and data scientists who are building or planning to build reliable & robust RAG applications and want a practical mental model for when to introduce which evaluations as their system grows in complexity.
 
 The talk begins by introducing the use case: an AI-assisted IT support ticket resolution system that takes a ticket's title, description, comments, and log files as input and produces a one-shot resolution. 
 

--- a/src/content/sessions/YGUJEG.md
+++ b/src/content/sessions/YGUJEG.md
@@ -10,13 +10,17 @@ speakers:
 - SNSDVY
 layout: layout_2
 trackName: Data & AI
-graphicsLayout: left
-theme: charcoal_lemon
+abstract: "Improving in archery often goes beyond simply increasing your score; it
+  also means building consistency, tightening groupings, and recognising patterns
+  such as shots drifting off-centre.  However, tracking the final position of arrows
+  after each shot is a slow, imprecise, and awkward process. \r\n\r\nIn this talk,
+  I show how I trained and validated a computer vision pipeline using oriented object
+  detection to infer arrow locations and scores directly from a target image. By deploying
+  this system on a Raspberry Pi, the process becomes simple enough to use during regular
+  practice, while also creating a record of shot placement that can be analysed over
+  time. This makes it possible to look beyond individual scores and start tracking
+  broader patterns in accuracy and consistency."
 ---
-
-Improving in archery often goes beyond simply increasing your score; it also means building consistency, tightening groupings, and recognising patterns such as shots drifting off-centre.  However, tracking the final position of arrows after each shot is a slow, imprecise, and awkward process. 
-
-In this talk, I show how I trained and validated a computer vision pipeline using oriented object detection to infer arrow locations and scores directly from a target image. By deploying this system on a Raspberry Pi, the process becomes simple enough to use during regular practice, while also creating a record of shot placement that can be analysed over time. This makes it possible to look beyond individual scores and start tracking broader patterns in accuracy and consistency.
 
 This talk goes beyond just detecting objects in an image: I cover the realities of hand annotating hundreds of training images, transforming model predictions into calibrated target co-ordinates, inferring scores from geometry, wrangling with validation, and making the whole thing usable in the field. 
 

--- a/src/content/sessions/ZJET3E.md
+++ b/src/content/sessions/ZJET3E.md
@@ -10,11 +10,9 @@ speakers:
 - APHKDN
 layout: layout_2
 trackName: Main Conference
-graphicsLayout: left
-theme: accent_emerald
+abstract: If Australia's electoral districts were drawn just a bit differently 
+  (or by a lot), how much would that change election results?
 ---
-
-If Australia's electoral districts were drawn just a bit differently (or by a lot), how much would that change election results?
 
 The Australian Electoral Commission (AEC) controls electoral boundaries in Australia - they do a fantastic job. They also provide us with voting data that shows us how different booths vote. Could we take this data and become the anti-AEC?
 

--- a/src/content/sessions/ZPGW8C.md
+++ b/src/content/sessions/ZPGW8C.md
@@ -10,34 +10,51 @@ speakers:
 - RBDJUT
 layout: layout_2
 trackName: Research Software Engineering
-graphicsLayout: left
-theme: accent_violet
+abstract: "_You’ve shared your code. You’ve shared your data.…so why can’t anyone
+  reproduce your results?_\r\n\r\nIn real-world research projects, reproducibility
+  often breaks in subtle ways, missing dependencies, unclear workflows, undocumented
+  steps, or environments that no longer work. These issues don’t appear all at once;
+  they emerge gradually as research evolves. In this talk, I introduce the idea of
+  Reproducibility Debt as a way to understand how these issues accumulate over time.
+  Importantly, this debt is not simply the result of poor practice, it reflects real-world
+  constraints such as time pressure, experimentation, and shifting project goals.
+  While reproducibility is often framed as a technical problem, solved through tools
+  like Docker, Conda, or better documentation, it is in reality a multi-faceted challenge
+  shaped by the interaction between technical, organisational, and human factors.
+  Rather than focusing on technical fixes alone, this talk takes a socio-technical
+  perspective: how decisions, trade-offs, and team practices influence reproducibility
+  outcomes. I will show how reproducibility can be approached as something to understand,
+  assess, and manage throughout a project, rather than something to fix at the end.\r\
+  \n\r\nThe talk introduces a lightweight way of identifying and tracking reproducibility
+  risks based on a structured view of common contributing factors. If you have ever
+  struggled to rerun your own code, or someone else’s, this talk offers a different
+  way to think about why, and what to do about it."
 ---
-
-_You’ve shared your code. You’ve shared your data.…so why can’t anyone reproduce your results?_
-
-In real-world research projects, reproducibility often breaks in subtle ways, missing dependencies, unclear workflows, undocumented steps, or environments that no longer work. These issues don’t appear all at once; they emerge gradually as research evolves. In this talk, I introduce the idea of Reproducibility Debt as a way to understand how these issues accumulate over time. Importantly, this debt is not simply the result of poor practice, it reflects real-world constraints such as time pressure, experimentation, and shifting project goals. While reproducibility is often framed as a technical problem, solved through tools like Docker, Conda, or better documentation, it is in reality a multi-faceted challenge shaped by the interaction between technical, organisational, and human factors. Rather than focusing on technical fixes alone, this talk takes a socio-technical perspective: how decisions, trade-offs, and team practices influence reproducibility outcomes. I will show how reproducibility can be approached as something to understand, assess, and manage throughout a project, rather than something to fix at the end.
-The talk introduces a lightweight way of identifying and tracking reproducibility risks based on a structured view of common contributing factors. If you have ever struggled to rerun your own code, or someone else’s, this talk offers a different way to think about why, and what to do about it.
 
 Reproducibility is widely recognised as important, yet in practice it is often treated as a final step, something to address once development is complete. In fast-moving research environments, this approach rarely works.
 This talk reframes reproducibility as a continuous, socio-technical challenge shaped by the interaction between code, environments, workflows, and human decision-making. Rather than presenting a checklist of tools, this talk emphasises that reproducibility is not only about using Docker, Conda, or improving code structure. These are useful, but they address only part of the problem. Reproducibility challenges arise from a broader set of interacting factors that need to be understood and managed over time.
+
 We will cover:
-•	how reproducibility issues emerge from everyday development decisions 
-•	why “perfect reproducibility” is often unrealistic in practice 
-•	how reproducibility debt accumulates as a natural part of research work 
-•	a structured view (taxonomy) of common factors contributing to reproducibility challenges 
-•	how to identify, assess, and track reproducibility risks throughout a project 
-•	when to fix issues, when to defer them, and how to make them visible for others 
+
+- how reproducibility issues emerge from everyday development decisions 
+- why “perfect reproducibility” is often unrealistic in practice 
+- how reproducibility debt accumulates as a natural part of research work 
+- a structured view (taxonomy) of common factors contributing to reproducibility challenges 
+- how to identify, assess, and track reproducibility risks throughout a project 
+- when to fix issues, when to defer them, and how to make them visible for others 
+
 The session includes a practical “before vs after” example and highlights how reproducibility can be treated as an ongoing, manageable concern rather than a one-time fix. This perspective is particularly relevant for research software engineers and developers working in dynamic, exploratory environments.
 
 **Audience**
-•	Research Software Engineers 
-•	PhD students and academic researchers 
-•	Python developers working in data-intensive or exploratory projects 
+
+- Research Software Engineers 
+- PhD students and academic researchers 
+- Python developers working in data-intensive or exploratory projects 
 
 **Key Takeaways**
-•	Reframe reproducibility as a socio-technical and multi-faceted challenge 
-•	Understand the different factors that contribute to reproducibility issues 
-•	Learn how to identify and track reproducibility risks over time 
-•	Move from “fixing at the end” to managing throughout the project 
-•	Apply practical strategies that balance development speed and reproducibility
+
+- Reframe reproducibility as a socio-technical and multi-faceted challenge 
+- Understand the different factors that contribute to reproducibility issues 
+- Learn how to identify and track reproducibility risks over time 
+- Move from “fixing at the end” to managing throughout the project 
+- Apply practical strategies that balance development speed and reproducibility

--- a/src/pages/schedule/[code].astro
+++ b/src/pages/schedule/[code].astro
@@ -9,6 +9,7 @@ import {
   getTrackBySlug,
   formatSessionDateTime,
 } from "../../utils/schedule";
+import { marked } from "marked";
 
 export async function getStaticPaths() {
   const sessions = await getCollection("sessions");
@@ -19,8 +20,11 @@ export async function getStaticPaths() {
 }
 
 const { session } = Astro.props;
-const { title, code, start, end, room, track, trackName, type, speakers, sponsor, contentWarning } =
+const { title, code, start, end, room, track, trackName, type, speakers, sponsor, contentWarning, abstract } =
   session.data;
+
+// Render abstract markdown to HTML
+const abstractHtml = abstract ? marked.parse(abstract) : null;
 
 // Canonical session URL for sharing
 const sessionUrl = new URL(`/schedule/${code}`, Astro.site ?? "https://2026.pycon.org.au").toString();
@@ -125,6 +129,7 @@ if (trackData) {
           )}
 
           <div class="rich-text pt-24 fadeInUp prose prose-lg max-w-none">
+            {abstractHtml && <div class="text-intro" set:html={abstractHtml} />}
             <Content />
           </div>
 
@@ -192,6 +197,7 @@ if (trackData) {
                   <div class="flex items-center gap-4">
                   <button
                     id="copy-link-btn"
+                    data-url={sessionUrl}
                     class="inline-flex items-center gap-2 text-sm font-semibold text-charcoal hover:text-emerald transition-colors cursor-pointer"
                     aria-label="Copy link to clipboard"
                   >
@@ -237,11 +243,12 @@ if (trackData) {
   <Footer />
 
   <script src="/src/scripts/animations.js"></script>
-  <script is:inline define:vars={{ sessionUrl }}>
+  <script>
     const btn = document.getElementById("copy-link-btn");
     if (btn) {
       btn.addEventListener("click", async () => {
-        await navigator.clipboard.writeText(sessionUrl);
+        const url = btn.dataset.url ?? window.location.href;
+        await navigator.clipboard.writeText(url);
         const icon = btn.querySelector("i");
         icon.className = "fa-solid fa-check text-2xl";
         btn.classList.add("text-emerald");

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -205,11 +205,13 @@ footer ul li a {
   @apply text-xs;
 }
 
-.text-intro {
-  @apply font-sans text-lg tracking-[0.01em] leading-[1.45];
+.text-intro,
+.text-intro p {
+  @apply font-sans text-xl tracking-[0.01em] leading-[1.45]!;
 }
 
-.rich-text p.text-intro + p {
+.rich-text p.text-intro + p,
+.rich-text div.text-intro + p {
   @apply mt-14;
 }
 .rich-text {


### PR DESCRIPTION
- Split abstract out of markdown body into frontmatter field
- Render abstract via marked for markdown support, styled as text-intro
- Description-only content remains in the markdown body
- Add marked dependency for client-side markdown parsing