### PR TITLE
Hotfix: exclude not-yet-announced sessions from specialist track pages

### DIFF
--- a/src/utils/schedule.ts
+++ b/src/utils/schedule.ts
@@ -196,7 +196,7 @@ export async function getSessionsForSpecialistTrack(
 
   const sessions = await getCollection("sessions");
   return sessions
-    .filter((session) => matchingSlugs.includes(session.data.track ?? ""))
+    .filter((session) => matchingSlugs.includes(session.data.track ?? "") && !session.data.tags?.includes("not-yet-announced"))
     .sort((a, b) => {
       const aStart = a.data.start?.getTime() ?? 0;
       const bStart = b.data.start?.getTime() ?? 0;


### PR DESCRIPTION
## Summary

- `not-yet-announced` sessions were appearing in specialist track list pages but linking to a 404 (no detail page is generated for them)
- Filter them out in `getSessionsForSpecialistTrack` in `src/utils/schedule.ts`

## Test plan

- [ ] Visit a specialist track page that has a `not-yet-announced` session — confirm it's not listed
- [ ] Confirm announced sessions in the same track still appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)