### PR TITLE
Update roadmap link to schedule link on homepage

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -160,12 +160,12 @@ const schemaData = {
           Attendee Guide
         </ImageCard>
         <ImageCard
-          href="/posts/2026-conference-roadmap"
+          href="/schedule"
           src="/images/thumb-3.png"
           alt="Repeating Violet Curlyboi on black background"
-          title="Conference Roadmap"
+          title="Schedule"
         >
-          Conference Roadmap
+          Schedule
         </ImageCard>
       </div>
     </div>


### PR DESCRIPTION
This PR updates a link on the home page from "Conference Roadmap" to "Schedule."

When I built this it worked. But please note, I am not a dev, so if you are interested in merging this PR, somebody will need to confirm I have made the changes correctly :-).

I also wasn't sure whether you would want the same image (/images/thumb-3.png) used, or whether you would want it changed. But when I had a look in the image file, I couldn't see a thumb-4 image, so figured I would submit this PR leaving the image as is.

Nic Crouch said I was welcome to put up a PR. If this is helpful, great. But if it is not wanted, no worries :-).
