### PR TITLE
Update text on buttons from "Early-Bird Tickets" and "Blind-Bird Tickets" to "Get Tickets"

### DIFF
--- a/src/pages/about/index.astro
+++ b/src/pages/about/index.astro
@@ -73,7 +73,7 @@ import ConnectSubscribeGetInTouchCards from "../../components/ConnectSubscribeGe
               <a
                 href="/tickets"
                 class="btn-arrow btn-arrow--emerald"
-                >Early-Bird Tickets</a
+                >Get Tickets</a
               >
             </div>
           </div>

--- a/src/pages/attend/index.astro
+++ b/src/pages/attend/index.astro
@@ -103,7 +103,7 @@ const bgColors = ["bg-violet", "bg-lavender"];
             </p>
             <div>
               <a href="/tickets" class="btn-arrow btn-arrow--emerald"
-                >Blind-Bird Tickets</a
+                >Get Tickets</a
               >
             </div>
           </div>


### PR DESCRIPTION
This PR updates the text on two buttons.

(1) On src/pages/about/index.astro updates button text from "Early-Bird Tickets" to "Get Tickets"

(2) On src/pages/attend/index.astro updates text from "Blind-Bird Tickets" to "Get Tickets".

**Edit to add:** I wasn't sure if the preferred text was "Get Tickets", "Register today" or "Register now" - the website appears to use a mixture of these phrases. If you would prefer the text to be "Register today", "Register now" or something else, I am happy to modify this PR accordingly. (Or you can simply close the PR).


