### PR TITLE
Schedule overview page updates

### DIFF
--- a/src/pages/schedule/index.astro
+++ b/src/pages/schedule/index.astro
@@ -5,6 +5,7 @@ import Footer from "../../components/Footer.astro";
 import Header from "../../components/Header.astro";
 import HeaderStar from "../../components/header/HeaderStar.astro";
 import DayTabs from "../../components/schedule/DayTabs.astro";
+import TypographyLink from "../../components/typography/TypographyLink.astro";
 import Base from "../../layouts/Base.astro";
 
 const allTracks = await getCollection("schedule-specialist-tracks");
@@ -117,7 +118,10 @@ const tracks = allTracks.sort((a, b) => {
             </a>
 
             <!-- Main Conference -->
-            <div class="fadeInUp block p-6 lg:p-8 rounded-2xl bg-lime">
+            <a
+              href="#main-conference"
+              class="fadeInUp block p-6 lg:p-8 rounded-2xl bg-lime"
+            >
               <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4">
                 <div class="flex-1">
                   <h2 class="text-2xl lg:text-3xl font-serif font-bold text-charcoal mb-1">
@@ -132,8 +136,9 @@ const tracks = allTracks.sort((a, b) => {
                     Three days of talks all about Python!
                   </p>
                 </div>
+              
               </div>
-            </div>
+            </a>  
 
             <!-- Sprints -->
             <div class="fadeInUp block p-6 lg:p-8 rounded-2xl bg-lemon">
@@ -202,6 +207,28 @@ const tracks = allTracks.sort((a, b) => {
                 </div>
               </a>
             ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section id="main-conference">
+    <div class="bg-stone pb-20">
+      <div class="container">
+        <div class="lg:w-[85%] w-full mx-auto">
+          <h2 class="fadeInUp text-4xl font-serif font-medium -tracking-[0.02em] mb-8">
+            Main Conference
+          </h2>
+          <p class="fadeInUp text-charcoal font-sans text-lg mb-10">
+            This is the core of PyCon AU. Each day starts with an amazing keynote talk, followed by talks on a diverse range of Python related topics. There will be a mix of beginner friendly and advanced talks on both technical and non-technical topics.
+          </p>
+          <p>
+            The main conference track runs concurrently with the specialist tracks on Thursday 27 August <TypographyLink href="/schedule/thursday">(Thursday schedule)</TypographyLink>, Friday 28 August <TypographyLink href="/schedule/friday">(Friday schedule)</TypographyLink> and Saturday 29 August <TypographyLink href="/schedule/saturday">(Saturday schedule)</TypographyLink>.
+          </p>  
+          <div class="grid lg:grid-cols-2 gap-6">
+                </div>
+              </a>
           </div>
         </div>
       </div>

--- a/src/pages/schedule/index.astro
+++ b/src/pages/schedule/index.astro
@@ -222,8 +222,8 @@ const tracks = allTracks.sort((a, b) => {
           </h2>
           <p class="fadeInUp text-charcoal font-sans text-lg mb-10">
             This is the core of PyCon AU. Each day starts with an amazing keynote talk, followed by talks on a diverse range of Python related topics. There will be a mix of beginner friendly and advanced talks on both technical and non-technical topics.
-          </p>
-          <p>
+          <br>
+          <br>
             The main conference track runs concurrently with the specialist tracks on Thursday 27 August <TypographyLink href="/schedule/thursday">(Thursday schedule)</TypographyLink>, Friday 28 August <TypographyLink href="/schedule/friday">(Friday schedule)</TypographyLink> and Saturday 29 August <TypographyLink href="/schedule/saturday">(Saturday schedule)</TypographyLink>.
           </p>  
           <div class="grid lg:grid-cols-2 gap-6">

--- a/src/pages/schedule/index.astro
+++ b/src/pages/schedule/index.astro
@@ -224,7 +224,7 @@ const tracks = allTracks.sort((a, b) => {
             This is the core of PyCon AU. Each day starts with an amazing keynote talk, followed by talks on a diverse range of Python related topics. There will be a mix of beginner friendly and advanced talks on both technical and non-technical topics.
           <br>
           <br>
-            The main conference track runs concurrently with the specialist tracks on Thursday 27 August <TypographyLink href="/schedule/thursday">(Thursday schedule)</TypographyLink>, Friday 28 August <TypographyLink href="/schedule/friday">(Friday schedule)</TypographyLink> and Saturday 29 August <TypographyLink href="/schedule/saturday">(Saturday schedule)</TypographyLink>.
+            The main conference runs concurrently with the specialist tracks on <TypographyLink href="/schedule/thursday">Thursday 27 August</TypographyLink>, <TypographyLink href="/schedule/friday">Friday 28 August</TypographyLink> and <TypographyLink href="/schedule/saturday">Saturday 29 August</TypographyLink>.
           </p>  
           <div class="grid lg:grid-cols-2 gap-6">
                 </div>


### PR DESCRIPTION
This PR adds a section about the Main Conference to the schedule overview page.

When I went looking for information about the Main Conference, I had surprising difficulty finding the schedule for the main conference talks. I initially kept overlooking the buttons towards the top of the page that link to the schedule for Thursday, Friday and Saturday, and as such could not figure out which talks were in the main conference and when they were scheduled. (I did eventually figure it out). 

I mentioned this to Nic Crouch, who said to feel free to put up a PR. So here is a PR :-). 

This PR:
- Adds an anchor element, so when you click on the big green "Main Conference" box it takes you to a (new) "Main Conference" section on the page.
- Adds a new "Main Conference" section, with a brief description and links to the schedule pages for Thursday, Friday and Saturday. 
- The text I added about the Main Conference is a modified version of the text I found here: https://2026.pycon.org.au/about/the-conference/ 

I also have almost no HTML experience, so apologies if I haven't formatted things correctly.

If these proposed changes are not helpful, then no worries. 

Also, I wonder if one of the reason I had initial trouble noticing the "Overview", "Wednesday", "Thursday", "Friday", "Saturday" and "Sunday" buttons towards the top of the page is because they have the same background colour as the surrounding page. I have no idea if changing the background colour is an easy change, or a difficult one. But I thought I would mention it just in case anyone thought it was worth addressing. 