### PR TITLE
Commit speaker avatars in schedule sync workflow

### DIFF
--- a/.github/workflows/update_schedule.yml
+++ b/.github/workflows/update_schedule.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: EndBug/add-and-commit@v9
         id: add-and-commit
         with:
-          add: 'src/content/sessions src/content/people'
+          add: 'src/content/sessions src/content/people public/images/people'
           author_name: GitHub Actions
           author_email: program@pycon.org.au
           message: "Auto-update the schedule from Pretalx"


### PR DESCRIPTION
## Problem

Speaker profile images are missing on the live site (e.g. [/schedule/CGG8LN/](https://2026.pycon.org.au/schedule/CGG8LN/)) even though the speaker uploaded a photo and the **Update schedule** action ran successfully. The promotional share graphics also lack the photo.

## Root cause

`scripts/schedule_sync.py` deletes the entire `public/images/people/` directory each run and re-downloads avatars into it, writing `hasAvatar: true` into the speaker `.md`. But the `EndBug/add-and-commit` step only staged:

```yaml
add: 'src/content/sessions src/content/people'
```

So the `.md` (with `hasAvatar: true`) got committed while the downloaded `.jpg` was **never** committed. On `origin/main`:

- `src/content/people/YZGZ9W.md` → `hasAvatar: true` ✓ committed
- `public/images/people/YZGZ9W.jpg` → **missing** ✗ never committed

Both consumers then fail:
- `SpeakerCard.astro` renders `/images/people/<code>.jpg` → 404.
- `generate_graphics.py` (`paste_avatar`) silently skips the missing file → promo graphics have no photo.

Run logs ([27186448142](https://github.com/pyconau/2026-website/actions/runs/27186448142)) confirm it: `Downloaded 47 new/updated avatars`, the diff flips `hasAvatar: false → true`, yet the new JPGs were dropped at commit time.

## Fix

Add `public/images/people` to the staged paths so downloaded avatars are committed alongside the content markdown. The next sync run will commit the missing avatars automatically — no manual backfill needed.

## Follow-up (not in this PR)

One speaker's avatar failed to decode in CI (`cannot identify image file ... 8R97UF_KMqF5kN.webp`) — a truncated/corrupt download. Unrelated to this systemic fix; worth addressing separately if it recurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)