### PR TITLE
Surface the schedule across nav, schedule page, and homepage

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -122,6 +122,30 @@ const callForProposalsPages = Object.entries(cfpPages)
                   Specialist Tracks
                 </a>
               </li>
+              <li>
+                <a
+                  href="/schedule/thursday"
+                  class="text-sm font-semibold font-sans hover:text-emerald"
+                >
+                  Thursday
+                </a>
+              </li>
+              <li>
+                <a
+                  href="/schedule/friday"
+                  class="text-sm font-semibold font-sans hover:text-emerald"
+                >
+                  Friday
+                </a>
+              </li>
+              <li>
+                <a
+                  href="/schedule/saturday"
+                  class="text-sm font-semibold font-sans hover:text-emerald"
+                >
+                  Saturday
+                </a>
+              </li>
             </ul>
           </li>
           <li class="relative group">
@@ -300,8 +324,61 @@ const callForProposalsPages = Object.entries(cfpPages)
         <li x-show="openSubMenu === null">
           <a href="/sponsor"><span>Sponsors</span></a>
         </li>
-        <li x-show="openSubMenu === null">
-          <a href="/schedule"><span class="relative inline-block">Schedule<img src="/images/flourish.svg" alt="" class="absolute -top-3 -right-4 w-7 h-7" /></span></a>
+        <li
+          x-show="openSubMenu === null || openSubMenu === 'schedule'"
+          :class="{ 'sub-menu-open': openSubMenu === 'schedule' }"
+        >
+          <div class="has-child">
+            <a href="/schedule">
+              <span class="relative inline-block">Schedule<img src="/images/flourish.svg" alt="" class="absolute -top-3 -right-4 w-7 h-7" /></span>
+            </a>
+            <svg
+              @click="openSubMenu = openSubMenu === 'schedule' ? null : 'schedule'"
+              xmlns="http://www.w3.org/2000/svg"
+              width="15.966"
+              height="28.934"
+              viewBox="0 0 15.966 28.934"
+              :class="{ 'rotate-90': openSubMenu === 'schedule' }"
+              class=" transition-transform duration-100 ease-in-out"
+              ><g transform="translate(-30.906 0)"
+                ><g transform="translate(0 0)"
+                  ><path
+                    d="M26.347,28.934h-3a16.009,16.009,0,0,1,9.19-14.468,15.977,15.977,0,0,1-4.514-3.176A15.862,15.862,0,0,1,23.347,0h3a12.882,12.882,0,0,0,3.8,9.169,12.882,12.882,0,0,0,9.169,3.8v3A12.967,12.967,0,0,0,26.347,28.934Z"
+                    transform="translate(7.559)"></path></g
+                ></g
+              >
+            </svg>
+          </div>
+          <ul class="flex flex-col gap-3 py-5 mb-4 w-full transition-all duration-500 ease-in-out text-black bg-stone rounded-xl">
+            <li class="px-4">
+              <a
+                href="/schedule/specialist-tracks"
+                class="font-semibold text-2xl font-sans hover:text-emerald"
+                >Specialist Tracks</a
+              >
+            </li>
+            <li class="px-4">
+              <a
+                href="/schedule/thursday"
+                class="font-semibold text-2xl font-sans hover:text-emerald"
+                >Thursday</a
+              >
+            </li>
+            <li class="px-4">
+              <a
+                href="/schedule/friday"
+                class="font-semibold text-2xl font-sans hover:text-emerald"
+                >Friday</a
+              >
+            </li>
+            <li class="px-4">
+              <a
+                href="/schedule/saturday"
+                class="font-semibold text-2xl font-sans hover:text-emerald"
+                >Saturday</a
+              >
+            </li>
+          </ul>
         </li>
         <li x-show="openSubMenu === null">
           <a href="/news/"><span>News & Updates</span></a>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -92,9 +92,14 @@ const schemaData = {
             <Bold>Brisbane</Bold> August 26-30 • Sofitel Brisbane Central
           </p>
         </div>
-        <div>
+        <div class="flex flex-col items-center gap-4">
           <a href="/tickets" class="btn-arrow"
             ><span>Register now</span></a
+          >
+          <a
+            href="/schedule"
+            class="font-sans font-semibold text-violet underline-offset-4 hover:underline"
+            >Schedule out <span class="underline">now</span>!</a
           >
         </div>
       </div>

--- a/src/pages/schedule/index.astro
+++ b/src/pages/schedule/index.astro
@@ -66,11 +66,17 @@ const tracks = allTracks.sort((a, b) => {
       <div class="container">
         <div class="lg:w-[85%] w-full mx-auto">
           <!-- Day tabs -->
+          <h2 class="fadeInUp text-4xl font-serif font-medium -tracking-[0.02em] mb-8">
+            View the schedule
+          </h2>
           <div class="fadeInUp mb-10">
             <DayTabs currentDay="overview" />
           </div>
 
           <!-- Schedule overview cards -->
+          <h2 class="fadeInUp text-4xl font-serif font-medium -tracking-[0.02em] mt-20 mb-8">
+            Overview
+          </h2>
           <div class="space-y-4">
             <!-- Workshops -->
             <div class="fadeInUp block p-6 lg:p-8 rounded-2xl bg-violet">

--- a/src/pages/schedule/index.astro
+++ b/src/pages/schedule/index.astro
@@ -79,21 +79,21 @@ const tracks = allTracks.sort((a, b) => {
           </h2>
           <div class="space-y-4">
             <!-- Workshops -->
-            <div class="fadeInUp block p-6 lg:p-8 rounded-2xl bg-violet">
+            <div class="fadeInUp block p-6 lg:p-8 rounded-2xl bg-lavender">
               <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4">
                 <div class="flex-1">
-                  <h2 class="text-2xl lg:text-3xl font-serif font-bold text-white mb-1">
+                  <h2 class="text-2xl lg:text-3xl font-serif font-bold text-charcoal mb-1">
                     Workshops
                   </h2>
-                  <p class="text-white/70 font-sans text-sm">
+                  <p class="text-charcoal/70 font-sans text-sm">
                     Wednesday 26 August
                   </p>
                 </div>
                 <div class="flex-1 lg:text-right">
-                  <p class="text-white font-sans mb-2">
+                  <p class="text-charcoal font-sans mb-2">
                     Workshops are free to attend but space is limited!
                   </p>
-                  <p class="text-white font-sans font-bold!">
+                  <p class="text-charcoal font-sans font-bold!">
                     Ticketed Separately
                   </p>
                 </div>


### PR DESCRIPTION
Makes the now-published schedule more visible across the site.

## Changes
- **Nav (desktop + mobile):** add Thursday / Friday / Saturday links beneath Specialist Tracks in the Schedule dropdown. Top-level Schedule still links to the overview; mobile gains an expandable submenu matching the About pattern.
- **/schedule:** add "View the schedule" heading above the day tabs and "Overview" above the overview cards (matching the Specialist Tracks heading style).
- **/schedule:** restyle the Workshops card from violet to lavender with charcoal text, consistent with the other overview cards.
- **Homepage hero:** add a "Schedule out now!" link under the Register now CTA (violet, "now" underlined, full underline on hover).

🤖 Generated with [Claude Code](https://claude.com/claude-code)