### PR TITLE
Add ticket pricing card and polish to specialist track pages

### DIFF
--- a/src/components/schedule/TrackTicketCard.astro
+++ b/src/components/schedule/TrackTicketCard.astro
@@ -45,24 +45,29 @@ const { trackName, date, tiers, buttonClass = "btn-arrow--emerald" } =
     <div class="space-y-8">
       {
         tiers.map((tier) => (
-          <div class="flex justify-between items-start gap-4">
-            <div class="space-y-2">
-              <h3 class={`${tier.nameColour} font-sans font-semibold text-2xl`}>
+          <div class="space-y-2">
+            <div class="flex justify-between items-end gap-4">
+              <h3 class={`${tier.nameColour} font-sans font-semibold text-2xl leading-none`}>
                 {tier.name}
               </h3>
+              <div class="price text-left shrink-0">
+                <span class="text-charcoal/50 text-xs font-sans block leading-none mb-1">
+                  From
+                </span>
+                <span class="text-charcoal text-2xl font-semibold font-sans block leading-none">
+                  {tier.price}
+                </span>
+              </div>
+            </div>
+            <div class="flex justify-between items-start gap-4">
               <p class="text-charcoal/60 font-sans text-xs! leading-snug max-w-[180px]">
                 {tier.description}
               </p>
-            </div>
-            <div class="price text-right shrink-0">
-              <span class="text-charcoal text-2xl font-semibold font-sans">
-                {tier.price}
-              </span>
               {tier.secondaryPrice && (
-                <span class="text-charcoal/50 text-base font-sans tracking-[0.01em] block leading-tight mt-2">
+                <span class="text-charcoal/50 text-base font-sans tracking-[0.01em] block leading-none shrink-0 text-right">
                   <span class="text-xs">or</span> {tier.secondaryPrice}
                   <br />
-                  {tier.secondaryLabel}
+                  <span class="text-xs">{tier.secondaryLabel}</span>
                 </span>
               )}
             </div>

--- a/src/components/schedule/TrackTicketCard.astro
+++ b/src/components/schedule/TrackTicketCard.astro
@@ -1,0 +1,79 @@
+---
+import { TICKETING_URL } from "../../constants";
+
+interface TicketTier {
+  /** Ticket type name, e.g. "Professional" */
+  name: string;
+  /** Tailwind text colour class for the name, e.g. "text-emerald" */
+  nameColour: string;
+  /** Short description shown under the heading */
+  description: string;
+  /** Headline (primary) price, e.g. "$380" */
+  price: string;
+  /** Secondary price line, e.g. "$850" */
+  secondaryPrice?: string;
+  /** Suffix for the secondary price, e.g. "for 3-days" */
+  secondaryLabel?: string;
+}
+
+export type { TicketTier };
+
+interface Props {
+  trackName: string;
+  date: string;
+  tiers: TicketTier[];
+  buttonClass?: string;
+}
+
+const { trackName, date, tiers, buttonClass = "btn-arrow--emerald" } =
+  Astro.props;
+---
+
+<div class="fadeInUp bg-white py-12 px-8 lg:px-10 w-full max-w-[426px]">
+  <div class="flex flex-col gap-10 h-full justify-between">
+    <div class="text-center text-charcoal">
+      <span class="block font-serif text-sm -tracking-[0.02em]">
+        Attend
+      </span>
+      <h2 class="font-serif text-3xl -tracking-[0.02em] leading-tight">
+        {trackName}
+      </h2>
+      <span class="block font-sans text-sm text-charcoal/60 mt-1">
+        {date}
+      </span>
+    </div>
+    <div class="space-y-8">
+      {
+        tiers.map((tier) => (
+          <div class="flex justify-between items-start gap-4">
+            <div class="space-y-2">
+              <h3 class={`${tier.nameColour} font-sans font-semibold text-2xl`}>
+                {tier.name}
+              </h3>
+              <p class="text-charcoal/60 font-sans text-xs! leading-snug max-w-[180px]">
+                {tier.description}
+              </p>
+            </div>
+            <div class="price text-right shrink-0">
+              <span class="text-charcoal text-2xl font-semibold font-sans">
+                {tier.price}
+              </span>
+              {tier.secondaryPrice && (
+                <span class="text-charcoal/50 text-base font-sans tracking-[0.01em] block leading-tight mt-2">
+                  <span class="text-xs">or</span> {tier.secondaryPrice}
+                  <br />
+                  {tier.secondaryLabel}
+                </span>
+              )}
+            </div>
+          </div>
+        ))
+      }
+    </div>
+    <a
+      href={TICKETING_URL}
+      class={`btn-arrow ${buttonClass} rounded-[3.125rem]! hover:rounded-none! justify-between py-5!`}
+      ><span>Register today</span></a
+    >
+  </div>
+</div>

--- a/src/content/cfp-specialist-tracks/platform-engineering.md
+++ b/src/content/cfp-specialist-tracks/platform-engineering.md
@@ -1,6 +1,6 @@
 ---
 title: "Platform Engineering"
-shortDescription: "Share and explore how Platform Engineering ideas such as systems thinking, guardrails, and golden paths empower teams to get their code from commit to production quickly and safely!"
+shortDescription: "Share and explore how platform engineering ideas such as systems thinking, guardrails, and golden paths empower teams to get their code from commit to production quickly and safely!"
 organisers:
   - name: Evan Kohilas
     title: "Platform Senior Software Engineer"

--- a/src/content/cfp-specialist-tracks/research-software-engineering.md
+++ b/src/content/cfp-specialist-tracks/research-software-engineering.md
@@ -20,7 +20,7 @@ organisers:
 
 This track includes topics related to:
 * the use of software engineering practices within Python and mixed-language code bases, especially code used for research or created by researchers
-* the use of Python-based software tools (e.g. Spack) within the research software engineering (RSE) ecosystem.
+* the use of Python-based software tools within the research software engineering (RSE) ecosystem.
 * building bridges between the Python and RSE communities.
 
 **This track would be great for:** Researchers, managers and software engineers thinking of using Python and software engineering practices to make software more robust and more usable for reproducible research.

--- a/src/content/schedule-specialist-tracks/platform-engineering.md
+++ b/src/content/schedule-specialist-tracks/platform-engineering.md
@@ -1,7 +1,7 @@
 ---
 title: "Platform Engineering"
 pretalxTrack: "Platform Engineering"
-shortDescription: "Share and explore how Platform Engineering ideas such as systems thinking, guardrails, and golden paths empower teams to get their code from commit to production quickly and safely!"
+shortDescription: "Share and explore how platform engineering ideas such as systems thinking, guardrails, and golden paths empower teams to get their code from commit to production quickly and safely!"
 date: 2026-08-27
 ---
 

--- a/src/content/schedule-specialist-tracks/research-software-engineering.md
+++ b/src/content/schedule-specialist-tracks/research-software-engineering.md
@@ -7,5 +7,5 @@ date: 2026-08-29
 
 This track includes topics related to:
 * the use of software engineering practices within Python and mixed-language code bases, especially code used for research or created by researchers
-* the use of Python-based software tools (e.g. Spack) within the research software engineering (RSE) ecosystem.
+* the use of Python-based software tools within the research software engineering (RSE) ecosystem.
 * building bridges between the Python and RSE communities.

--- a/src/pages/schedule/[day].astro
+++ b/src/pages/schedule/[day].astro
@@ -1,4 +1,5 @@
 ---
+import { getCollection } from "astro:content";
 import Footer from "../../components/Footer.astro";
 import Header from "../../components/Header.astro";
 import DayTabs from "../../components/schedule/DayTabs.astro";
@@ -33,6 +34,12 @@ const allSessions = await getSessionsByDay(day);
 const allSpeakerCodes = allSessions.flatMap((s) => s.data.speakers || []);
 const allSpeakers = await getPeopleByCode([...new Set(allSpeakerCodes)]);
 const speakerMap = new Map(allSpeakers.map((s) => [s.data.code, s]));
+
+// Slugs that have a specialist track page, so we only link track names that
+// resolve to a real page.
+const trackSlugs = new Set(
+  (await getCollection("schedule-specialist-tracks")).map((t) => t.slug)
+);
 ---
 
 <Base title={`${dayCapitalized} Schedule - Schedule`}>
@@ -211,6 +218,10 @@ const speakerMap = new Map(allSpeakers.map((s) => [s.data.code, s]));
                           ? formatSessionTime(ps.session.data.start, ps.session.data.end)
                           : "";
                         const trackName = ps.session.data.trackName;
+                        const trackSlug = ps.session.data.track;
+                        const trackHref = trackSlug && trackSlugs.has(trackSlug)
+                          ? `/schedule/specialist-tracks/${trackSlug}`
+                          : null;
 
                         const EventTag = isNotYetAnnounced ? "div" : "a";
                         return (
@@ -231,7 +242,11 @@ const speakerMap = new Map(allSpeakers.map((s) => [s.data.code, s]));
                                     </g>
                                   </g>
                                 </svg>
-                                <span class="schedule-track-name">{trackName}</span>
+                                {trackHref ? (
+                                  <a href={trackHref} class="schedule-track-name schedule-track-name--link">{trackName}</a>
+                                ) : (
+                                  <span class="schedule-track-name">{trackName}</span>
+                                )}
                               </div>
                             )}
                             <EventTag

--- a/src/pages/schedule/specialist-tracks/[...slug].astro
+++ b/src/pages/schedule/specialist-tracks/[...slug].astro
@@ -155,7 +155,7 @@ const ticketTiers = TICKET_TIER_OVERRIDES[track.slug] ?? DEFAULT_TICKET_TIERS;
                 <h3 class="text-5xl font-serif font-medium -tracking-[0.02em]">
                   Sessions
                 </h3>
-                <a href={`/schedule/${dayParam}`} class="btn-arrow">
+                <a href={`/schedule/${dayParam}`} class="btn-arrow btn-arrow--lime">
                   <span>{weekday} schedule</span>
                 </a>
               </div>

--- a/src/pages/schedule/specialist-tracks/[...slug].astro
+++ b/src/pages/schedule/specialist-tracks/[...slug].astro
@@ -6,7 +6,46 @@ import HeaderStar from "../../../components/header/HeaderStar.astro";
 import Base from "../../../layouts/Base.astro";
 import SessionListItem from "../../../components/schedule/SessionListItem.astro";
 import TrackOrganiser from "../../../components/cfp/TrackOrganiser.astro";
+import TrackTicketCard from "../../../components/schedule/TrackTicketCard.astro";
+import type { TicketTier } from "../../../components/schedule/TrackTicketCard.astro";
 import { getSessionsForSpecialistTrack } from "../../../utils/schedule";
+
+// Default ticket pricing shown on every specialist track page. Mirrors the
+// Professional and Enthusiast cards on /tickets, leading with the one-day
+// price as the primary headline.
+const DEFAULT_TICKET_TIERS: TicketTier[] = [
+  {
+    name: "Professional",
+    nameColour: "text-emerald",
+    description: "For people who use Python professionally.",
+    price: "$380",
+    secondaryPrice: "$850",
+    secondaryLabel: "for 3-days",
+  },
+  {
+    name: "Enthusiast",
+    nameColour: "text-lavender",
+    description: "For enthusiasts paying their own way.",
+    price: "$250",
+    secondaryPrice: "$550",
+    secondaryLabel: "for 3-days",
+  },
+];
+
+// Per-track overrides keyed by slug. Education uses the Educator ticket from
+// /tickets instead of the default Professional/Enthusiast pricing.
+const TICKET_TIER_OVERRIDES: Record<string, TicketTier[]> = {
+  education: [
+    {
+      name: "Educator",
+      nameColour: "text-emerald",
+      description: "Subsidised ticket for school teachers.",
+      price: "$250",
+      secondaryPrice: "$550",
+      secondaryLabel: "for 3-days",
+    },
+  ],
+};
 
 export async function getStaticPaths() {
   const tracks = await getCollection("schedule-specialist-tracks");
@@ -17,8 +56,24 @@ export async function getStaticPaths() {
 }
 
 const { track } = Astro.props;
-const { title, shortDescription } = track.data;
+const { title, shortDescription, date } = track.data;
 const { Content } = await track.render();
+
+// e.g. "Friday 27 August"
+const formattedDate = new Intl.DateTimeFormat("en-AU", {
+  weekday: "long",
+  day: "numeric",
+  month: "long",
+  timeZone: "UTC",
+}).format(date);
+
+// Lowercase weekday name used as the /schedule/[day] route param, e.g. "friday".
+const dayParam = new Intl.DateTimeFormat("en-AU", {
+  weekday: "long",
+  timeZone: "UTC",
+})
+  .format(date)
+  .toLowerCase();
 
 // Get sessions for this track
 const sessions = await getSessionsForSpecialistTrack(track);
@@ -27,6 +82,9 @@ const sessions = await getSessionsForSpecialistTrack(track);
 const cfpTracks = await getCollection("cfp-specialist-tracks");
 const cfpTrack = cfpTracks.find((t) => t.slug === track.slug);
 const organisers = cfpTrack?.data.organisers || [];
+
+// Ticket pricing for this track (with per-slug overrides).
+const ticketTiers = TICKET_TIER_OVERRIDES[track.slug] ?? DEFAULT_TICKET_TIERS;
 ---
 
 <Base title={`${title} - Specialist Track`}>
@@ -35,7 +93,7 @@ const organisers = cfpTrack?.data.organisers || [];
   <section class="bg-charcoal pt-[98px] pb-20 overflow-hidden">
     <div class="container relative">
       <img
-        src="/images/star-violet.svg"
+        src="/images/star-lime.svg"
         class="hidden lg:block absolute left-0 top-32"
         alt=""
       />
@@ -55,8 +113,13 @@ const organisers = cfpTrack?.data.organisers || [];
         </div>
         <div class="fadeInUp flex justify-between items-center relative pt-10">
           <div class="space-y-20 lg:w-[45%] w-full relative">
-            <div class="font-serif lg:text-8xl text-[3.625rem] -tracking-[0.022em] leading-none">
-              <h1 class="text-lime">{title}</h1>
+            <div class="space-y-5">
+              <div class="font-serif lg:text-8xl text-[3.625rem] -tracking-[0.022em] leading-none">
+                <h1 class="text-lime">{title}</h1>
+              </div>
+              <p class="text-stone font-sans text-base tracking-[0.01em]">
+                Will run on {formattedDate}
+              </p>
             </div>
           </div>
         </div>
@@ -70,7 +133,7 @@ const organisers = cfpTrack?.data.organisers || [];
     <div class="bg-stone pt-20 pb-52">
       <div class="container">
         <div class="fadeInUp lg:w-[85%] w-full mx-auto">
-          <div class="flex lg:flex-row flex-col lg:gap-0 gap-10 justify-between items-start">
+          <div class="flex lg:flex-row flex-col lg:gap-20 gap-10 justify-between items-start">
             <div class="w-full lg:w-[646px]">
               <p class="text-intro font-medium text-charcoal fadeInUp">
                 {shortDescription}
@@ -79,18 +142,31 @@ const organisers = cfpTrack?.data.organisers || [];
                 <Content />
               </div>
             </div>
-            <div>
-              <a href="/tickets" class="btn-arrow btn-arrow--emerald">
-                Register today
-              </a>
-            </div>
+            <TrackTicketCard
+              trackName={title}
+              date={formattedDate}
+              tiers={ticketTiers}
+            />
           </div>
 
           {sessions.length > 0 && (
             <div class="pt-24">
-              <h3 class="fadeInUp text-5xl font-serif font-medium -tracking-[0.02em] mb-10">
-                Sessions
-              </h3>
+              <div class="fadeInUp flex flex-wrap items-baseline gap-x-10 gap-y-4 mb-10">
+                <h3 class="text-5xl font-serif font-medium -tracking-[0.02em]">
+                  Sessions
+                </h3>
+                <a
+                  href={`/schedule/${dayParam}`}
+                  class="group flex items-center gap-2 text-violet font-sans font-bold text-lg"
+                >
+                  <span class="group-hover:underline">View schedule</span>
+                  <img
+                    src="/images/arrow-small--violet.svg"
+                    alt=""
+                    class="w-7"
+                  />
+                </a>
+              </div>
 
               <div class="space-y-10">
                 {sessions.map((session) => (

--- a/src/pages/schedule/specialist-tracks/[...slug].astro
+++ b/src/pages/schedule/specialist-tracks/[...slug].astro
@@ -67,13 +67,13 @@ const formattedDate = new Intl.DateTimeFormat("en-AU", {
   timeZone: "UTC",
 }).format(date);
 
-// Lowercase weekday name used as the /schedule/[day] route param, e.g. "friday".
-const dayParam = new Intl.DateTimeFormat("en-AU", {
+// Weekday name, e.g. "Friday". Used for the "{Day} schedule" link label and,
+// lowercased, as the /schedule/[day] route param.
+const weekday = new Intl.DateTimeFormat("en-AU", {
   weekday: "long",
   timeZone: "UTC",
-})
-  .format(date)
-  .toLowerCase();
+}).format(date);
+const dayParam = weekday.toLowerCase();
 
 // Get sessions for this track
 const sessions = await getSessionsForSpecialistTrack(track);
@@ -151,20 +151,12 @@ const ticketTiers = TICKET_TIER_OVERRIDES[track.slug] ?? DEFAULT_TICKET_TIERS;
 
           {sessions.length > 0 && (
             <div class="pt-24">
-              <div class="fadeInUp flex flex-wrap items-baseline gap-x-10 gap-y-4 mb-10">
+              <div class="fadeInUp flex flex-wrap items-center justify-between gap-x-10 gap-y-4 mb-10">
                 <h3 class="text-5xl font-serif font-medium -tracking-[0.02em]">
                   Sessions
                 </h3>
-                <a
-                  href={`/schedule/${dayParam}`}
-                  class="group flex items-center gap-2 text-violet font-sans font-bold text-lg"
-                >
-                  <span class="group-hover:underline">View schedule</span>
-                  <img
-                    src="/images/arrow-small--violet.svg"
-                    alt=""
-                    class="w-7"
-                  />
+                <a href={`/schedule/${dayParam}`} class="btn-arrow">
+                  <span>{weekday} schedule</span>
                 </a>
               </div>
 

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -726,6 +726,13 @@ ul.sub-menu {
   @apply font-semibold text-[#747474];
 }
 
+.schedule-track-name--link {
+  @apply no-underline cursor-pointer transition-colors;
+}
+.schedule-track-name--link:hover {
+  @apply text-charcoal underline;
+}
+
 .schedule-event {
   @apply relative left-0 right-0;
   @apply bg-white text-charcoal font-sans font-medium text-xs px-4 py-2 rounded-[1.25rem] flex flex-col justify-between items-start;


### PR DESCRIPTION
## Summary

Reworks the specialist track pages (e.g. `/schedule/specialist-tracks/data-and-ai`) and adds related schedule polish.

- **Ticket pricing card** — replaces the plain "Register today" button with a vertical white card showing per-day primary pricing (Professional/Enthusiast by default, Educator for the Education track via a per-slug override). Card heading "Attend {track}", a small left-aligned "From" above each price, and a secondary "or $X / for 3-days" line. The button links to the pretix ticketing URL.
- **Hero date** — shows "Will run on {date}" under each track title.
- **Sessions → schedule link** — adds a lime `btn-arrow` labelled "{Day} schedule" (e.g. "Thursday schedule") beside the Sessions heading, right-aligned with the sessions column, deep-linking to the correct `/schedule/{day}`.
- **Lime hero star** — swaps the violet star for lime to match the lime heading/breadcrumbs.
- **Day grid track links** — track-name headers on the day schedule now link to their track page (only when the slug resolves), with a grey→black underline hover, no layout shift.
- **Copy** — drops the "(e.g. Spack)" example from the RSE track description; lowercases "platform engineering" within the Platform Engineering track description.

## Test plan

- [ ] Visit each specialist track page; confirm card pricing, Education override, hero date, and schedule button day/link.
- [ ] On the day schedule grid, hover and click track-name headers; confirm they link to the right track and main-conference names stay unlinked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)