### PR TITLE
Add Get Involved column to footer

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -98,6 +98,36 @@ import SubscribeModal from "./SubscribeModal.astro";
             </ul>
           </div>
         </div>
+        <ul class="space-y-2 lg:block hidden">
+          <li>
+            <span class="text-white/50 text-sm">Get Involved</span>
+          </li>
+          <li>
+            <a
+              href="https://github.com/pyconau/2026-website/pulls"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="hover:text-lime transition-all duration-300"
+              >Website pull requests</a
+            >
+          </li>
+          <li>
+            <a
+              href="/schedule/sunday"
+              class="hover:text-lime transition-all duration-300"
+              >Organise a development sprint</a
+            >
+          </li>
+          <li>
+            <a
+              href="https://github.com/pyconau/howto/wiki/Learn-to-run-a-PyCon-(AU)"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="hover:text-lime transition-all duration-300"
+              >Run a future PyCon AU</a
+            >
+          </li>
+        </ul>
         <div class="lg:block flex justify-between lg:mt-0 mt-14">
           <ul class="space-y-3 flex flex-col lg:hidden">
             <!-- <li><a href="#" class="text-lime font-medium">Program</a></li> -->
@@ -106,6 +136,34 @@ import SubscribeModal from "./SubscribeModal.astro";
               >
             </li>
             <li><a href="/about/" class="text-lime font-medium">About</a></li>
+            <li class="pt-2">
+              <span class="text-white/50 text-sm">Get Involved</span>
+            </li>
+            <li>
+              <a
+                href="https://github.com/pyconau/2026-website/pulls"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="hover:text-lime transition-all duration-300"
+                >Website pull requests</a
+              >
+            </li>
+            <li>
+              <a
+                href="/schedule/sunday"
+                class="hover:text-lime transition-all duration-300"
+                >Organise a development sprint</a
+              >
+            </li>
+            <li>
+              <a
+                href="https://github.com/pyconau/howto/wiki/Learn-to-run-a-PyCon-(AU)"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="hover:text-lime transition-all duration-300"
+                >Run a future PyCon AU</a
+              >
+            </li>
           </ul>
           <ul class="space-y-3">
             <li>


### PR DESCRIPTION
## Summary

Adds a new **Get Involved** column to the site footer, alongside the existing "Attendee Guide" and "About" columns, on both desktop and mobile layouts.

Links:
- **Website pull requests** → `https://github.com/pyconau/2026-website/pulls`
- **Organise a development sprint** → `/schedule/sunday`
- **Run a future PyCon AU** → `https://github.com/pyconau/howto/wiki/Learn-to-run-a-PyCon-(AU)`

## Notes

- GitHub links open in a new tab (`target="_blank"` + `rel="noopener noreferrer"`); the internal sprint link stays same-tab.
- The "Get Involved" heading is a non-link span styled in muted grey to match the footer's secondary text.
- The desktop column is spaced evenly between the Attendee Guide/About columns and the right-hand lavender links via the existing `justify-between` row.
- ⚠️ The "Organise a development sprint" link points to `/schedule/sunday`, which doesn't exist yet — it will 404 until that page is added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)