### PR TITLE
Add Sunday schedule page for development sprints

### DIFF
--- a/src/components/schedule/DayTabs.astro
+++ b/src/components/schedule/DayTabs.astro
@@ -5,7 +5,7 @@ interface Props {
 
 const { currentDay } = Astro.props;
 const allDays = ["wednesday", "thursday", "friday", "saturday", "sunday"];
-const publishedDays = ["thursday", "friday", "saturday"];
+const publishedDays = ["thursday", "friday", "saturday", "sunday"];
 ---
 
 <div class="flex flex-wrap justify-center gap-3">

--- a/src/pages/schedule/sunday.astro
+++ b/src/pages/schedule/sunday.astro
@@ -1,0 +1,196 @@
+---
+import Footer from "../../components/Footer.astro";
+import Header from "../../components/Header.astro";
+import DayTabs from "../../components/schedule/DayTabs.astro";
+import Base from "../../layouts/Base.astro";
+
+const day = "sunday";
+const dayCapitalized = "Sunday";
+const dateString = "Sunday, 30 August 2026";
+
+// Development sprints run as a single all-day session in one room.
+// Built manually as there is no Sunday session data in the schedule.
+const room = "Lyon";
+const sprintTime = "9:00 am - 5:00 pm";
+// Height matched to a single one-hour block in the detailed layout.
+const sprintHeightPx = 297;
+
+// Time gutter labels. The sprint runs 9am–5pm; we show a few markers down the
+// left and let the single block overlap them (it ends at 5pm, below the 3pm
+// marker). Positions are a percentage of the block height (9am = 0%, 5pm = 100%).
+const timeMarkers = [
+  { label: "9:00 am", topPercent: 0 },
+  { label: "12:00 pm", topPercent: 37.5 },
+  { label: "3:00 pm", topPercent: 75 },
+];
+---
+
+<Base title={`${dayCapitalized} Schedule - Schedule`}>
+  <Header dark={false} />
+
+  <section class="bg-stone pt-[98px] pb-20 overflow-hidden">
+    <div class="container relative">
+      <img src="/images/star-violet.svg" class="spin lg:block hidden absolute left-0 top-32" alt="">
+      <div class="lg:w-[85%] w-full mx-auto">
+        <div class="fadeInUp breadcrumb pt-14">
+          <ul class="flex items-center gap-2 text-violet font-sans font-extrabold text-10pt uppercase tracking-[0.12em]">
+            <li class="flex items-center gap-2"><a href="/">Home</a><span>&gt;</span></li>
+            <li class="flex items-center gap-2"><a href="/schedule">Schedule</a><span>&gt;</span></li>
+            <li class="flex items-center gap-2"><span>{dayCapitalized}</span></li>
+          </ul>
+        </div>
+      </div>
+    </div>
+
+    <div class="container">
+      <div class="lg:w-[85%] w-full mx-auto relative pt-10">
+        <div class="fadeInUp w-full lg:w-[45%] relative">
+          <div class="font-serif lg:text-8xl text-[3.625rem] -tracking-[0.022em]">
+            <h1 class="text-violet">Schedule</h1>
+          </div>
+          <p class="text-charcoal text-lg mt-2">{dateString}</p>
+        </div>
+
+        <!-- Day Tabs -->
+        <div class="fadeInUp mt-10">
+          <DayTabs currentDay={day} />
+        </div>
+      </div>
+    </div>
+
+    <!-- Schedule Grid (single room, manually built) -->
+    <div
+      class="fadeInUp schedule-wrapper sunday-schedule"
+      style="--schedule-room-count: 1;"
+      data-rooms="1"
+      data-layout="detailed"
+    >
+      <!-- Room Headers -->
+      <div class="schedule-title">
+        <div class="space-for-time-column"></div>
+        <div class="schedule-title__room">
+          <span class="font-semibold font-serif">{room}</span>
+        </div>
+      </div>
+
+      <!-- Single all-day block, with time markers down the left gutter -->
+      <div class="schedule">
+        {timeMarkers.map((marker) => (
+          <div class="sunday-row-line" style={`top: ${marker.topPercent}%;`}></div>
+        ))}
+        <div class="time" style={`height: ${sprintHeightPx}px;`}>
+          {timeMarkers.map((marker) => (
+            <span class="sunday-time-marker" style={`top: ${marker.topPercent}%;`}>
+              {marker.label}
+            </span>
+          ))}
+        </div>
+        <div class="column" style={`height: ${sprintHeightPx}px;`}>
+          <div
+            class="schedule-event"
+            style={`height: ${sprintHeightPx}px; background-color: white; color: #282828;`}
+          >
+            <div>
+              <span class="schedule-event-time">{sprintTime}</span>
+            </div>
+            <div>
+              <span class="schedule-event-topic">Development Sprints</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="bg-stone pb-20">
+    <div class="container">
+      <div class="lg:w-[85%] w-full mx-auto rich-text">
+        <h2 class="fadeInUp mt-0!">About Development Sprints</h2>
+        <p class="fadeInUp">
+          Python wouldn’t have gotten to where it is without a welcoming
+          community of developers building cool things together. The
+          development sprints are an open space for people to work on
+          projects with a particular focus on open source projects.
+        </p>
+        <p class="fadeInUp">
+          The sprints are a place for everyone, from experienced open
+          source contributors, to interested first-time contributors, and
+          anyone really! Maybe you want to hang out and try out an idea
+          you have, maybe you’d like to find collaborators for a project
+          you want to start, maybe you’d like someone to help you through
+          your first attempts at open source. We’ll provide tables,
+          chairs, wifi, power and a community of supportive developers.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <section class="bg-lime pt-20">
+    <div class="container">
+      <div class="grid lg:grid-cols-2 grid-cols-1 gap-5 pb-20 fadeInUp">
+        <a href="/schedule/specialist-tracks" class="btn-arrow btn-arrow--emerald btn-arrow--2col">
+          <span>Specialist Tracks</span>
+        </a>
+        <a href="/schedule" class="btn-arrow btn-arrow--emerald btn-arrow--2col">
+          <span>Full Schedule</span>
+        </a>
+      </div>
+    </div>
+  </section>
+
+  <Footer />
+
+  <script src="/src/scripts/animations.js"></script>
+</Base>
+
+<style>
+  /* Single, brief all-day block: let the grid size to the bubble rather than
+     forcing fixed 160px slot heights (which would clip / scroll the taller
+     297px block). */
+  .sunday-schedule {
+    overflow: visible;
+  }
+  .sunday-schedule .schedule {
+    margin-top: 1.5rem;
+  }
+  .sunday-schedule .time,
+  .sunday-schedule .column {
+    min-height: 0;
+  }
+
+  /* Time markers down the gutter, positioned by percentage of the block height
+     so the single block visually overlaps them. */
+  .sunday-schedule .time {
+    position: relative;
+    padding-top: 0;
+  }
+  .sunday-time-marker {
+    position: absolute;
+    left: 0;
+    white-space: nowrap;
+  }
+
+  /* Horizontal slot lines spanning the grid, matching the other schedules. */
+  .sunday-schedule .schedule {
+    position: relative;
+  }
+  .sunday-row-line {
+    position: absolute;
+    left: 0;
+    right: 0;
+    border-bottom: 1px solid #dbdbdb;
+    pointer-events: none;
+    z-index: 0;
+  }
+
+  /* Match Thursday/Friday width: those days have 3 room columns and render the
+     .schedule grid ~1160px wide (1000px max-width + 80px time column overflow
+     within the 1200px min-width, with 20px padding either side). Replicate the
+     overall width here and let the single room column fill it. */
+  @media (min-width: 1024px) {
+    .sunday-schedule .schedule,
+    .sunday-schedule .schedule-title {
+      max-width: 1000px;
+    }
+  }
+</style>

--- a/src/pages/schedule/sunday.astro
+++ b/src/pages/schedule/sunday.astro
@@ -3,6 +3,7 @@ import Footer from "../../components/Footer.astro";
 import Header from "../../components/Header.astro";
 import DayTabs from "../../components/schedule/DayTabs.astro";
 import Base from "../../layouts/Base.astro";
+import { TICKETING_URL } from "../../constants";
 
 const day = "sunday";
 const dayCapitalized = "Sunday";
@@ -121,6 +122,55 @@ const timeMarkers = [
           your first attempts at open source. We’ll provide tables,
           chairs, wifi, power and a community of supportive developers.
         </p>
+      </div>
+
+      <div class="lg:w-[85%] w-full mx-auto mt-16">
+        <h2 class="fadeInUp font-serif lg:text-5xl text-4xl font-medium tracking-[-0.02em] leading-[1.3]">
+          Sprints Tickets
+        </h2>
+        <div class="grid lg:grid-cols-2 grid-cols-1 gap-5 mt-8">
+          <div class="fadeInUp bg-white py-12 px-8 lg:px-10 flex flex-col gap-8 justify-between">
+            <div class="flex flex-col gap-6">
+              <h3 class="text-emerald font-sans font-semibold text-2xl leading-none">
+                Contributor tickets
+              </h3>
+              <ul class="space-y-5 text-charcoal">
+                <li class="flex items-center gap-3">
+                  <img src="/images/tick-lemon.svg" alt="tick" />
+                  <span>Development Sprints are included</span>
+                </li>
+              </ul>
+            </div>
+            <a
+              href={TICKETING_URL}
+              class="btn-arrow btn-arrow--lemon rounded-[3.125rem]! hover:rounded-none! justify-between py-5!"
+              ><span>Register Today</span></a
+            >
+          </div>
+          <div class="fadeInUp bg-white py-12 px-8 lg:px-10 flex flex-col gap-8 justify-between">
+            <div class="flex flex-col gap-6">
+              <div class="flex justify-between items-end gap-4">
+                <h3 class="text-violet font-sans font-semibold text-2xl leading-none">
+                  Sprints tickets (add-on)
+                </h3>
+                <span class="text-charcoal text-2xl font-semibold font-sans block leading-none shrink-0">
+                  $150
+                </span>
+              </div>
+              <p class="text-charcoal font-sans text-base leading-snug">
+                Available as an add-on for <span class="text-emerald font-semibold">Professional</span>,
+                <span class="text-lavender font-semibold">Enthusiast</span>,
+                <span class="text-coral font-semibold">Student</span> and
+                <span class="text-emerald font-semibold">Educator</span> ticket types.
+              </p>
+            </div>
+            <a
+              href={TICKETING_URL}
+              class="btn-arrow btn-arrow--violet rounded-[3.125rem]! hover:rounded-none! justify-between py-5!"
+              ><span>Register Today</span></a
+            >
+          </div>
+        </div>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary
- Adds a new `/schedule/sunday` page for the Sunday development sprints, modelled on the existing schedule day pages (same Schedule header, date, and day nav).
- Single, manually-built all-day block in the **Lyon** room (9:00 am – 5:00 pm) with time markers (9 / 12 / 3) and slot lines matching the other schedule days.
- Enables **Sunday** in the schedule day-tab navigation.
- "About Development Sprints" section using the sprints copy from `/about/the-conference`.
- "Sprints Tickets" section with two white ticket cards:
  - **Contributor tickets** — Development Sprints included (lemon tick + lemon Register Today button).
  - **Sprints tickets (add-on)** — $150, with the other ticket types coloured to match `/tickets`, and a violet Register Today button.
  - Both cards link to the pretix ticketing URL.

## Test plan
- [ ] `npx astro check` passes (0 errors).
- [ ] Visit `/schedule/sunday` — header, date, day nav, single Lyon block with time markers/lines.
- [ ] Sunday tab is enabled and links correctly from other schedule pages.
- [ ] Both Register Today buttons link to pretix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)