### PR TITLE
Add Sunday to schedule navigation menu

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -128,6 +128,14 @@ const attendeeGuidePages = Object.entries(pages)
                   Saturday
                 </a>
               </li>
+              <li>
+                <a
+                  href="/schedule/sunday"
+                  class="text-sm font-semibold font-sans hover:text-emerald"
+                >
+                  Sunday
+                </a>
+              </li>
             </ul>
           </li>
           <li class="relative group">
@@ -358,6 +366,13 @@ const attendeeGuidePages = Object.entries(pages)
                 href="/schedule/saturday"
                 class="font-semibold text-2xl font-sans hover:text-emerald"
                 >Saturday</a
+              >
+            </li>
+            <li class="px-4">
+              <a
+                href="/schedule/sunday"
+                class="font-semibold text-2xl font-sans hover:text-emerald"
+                >Sunday</a
               >
             </li>
           </ul>


### PR DESCRIPTION
## Summary
Follow-up to the Sunday schedule page: adds the **Sunday** link to the site's Schedule navigation menu, which was missed previously.

- Desktop dropdown — adds Sunday after Saturday.
- Mobile menu — adds Sunday after Saturday.

## Test plan
- [ ] `npx astro check` passes (0 errors).
- [ ] Desktop: hover the Schedule nav — Sunday appears and links to `/schedule/sunday`.
- [ ] Mobile: open the menu, expand Schedule — Sunday appears and links correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)