### PR TITLE
Avoid showing epoch when session start time is missing

### DIFF
--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -5,8 +5,8 @@ const sessions = defineCollection({
   schema: z.object({
     title: z.string(),
     code: z.string(),
-    start: z.coerce.date(),
-    end: z.coerce.date(),
+    start: z.coerce.date().nullable(),
+    end: z.coerce.date().nullable(),
     room: z.string(),
     track: z.string().nullable().optional(), // Local slug for linking
     trackName: z.string().optional(), // Original Pretalx track name for display


### PR DESCRIPTION
This PR modifies the session parser to avoid fabricating a start time equal to the Linux epoch when a talk has not yet been scheduled.

**Before**

<img width="293" height="84" alt="Screenshot 2026-06-22 at 1 25 06 pm" src="https://github.com/user-attachments/assets/9a9a100d-f543-4b95-82c2-ff1349c7f974" />

**After**

<img width="395" height="85" alt="Screenshot 2026-06-22 at 1 25 51 pm" src="https://github.com/user-attachments/assets/a0e8061e-0edb-4e49-99c1-3a278e1f5b45" />

