### PR TITLE
Add "New ticket types now available" news post

### DIFF
--- a/src/content/posts/all-ticket-types-now-available.mdx
+++ b/src/content/posts/all-ticket-types-now-available.mdx
@@ -1,5 +1,5 @@
 ---
-title: "All ticket types now available"
+title: "New ticket types now available"
 published: 2026-06-29T09:00:00+10:00
 category: "news"
 previewText: "Now is the perfect time to register for PyCon AU 2026!"

--- a/src/content/posts/all-ticket-types-now-available.mdx
+++ b/src/content/posts/all-ticket-types-now-available.mdx
@@ -1,0 +1,61 @@
+---
+title: "All ticket types now available"
+published: 2026-06-29T09:00:00+10:00
+category: "news"
+previewText: "Now is the perfect time to register for PyCon AU 2026!"
+---
+
+Over the past few weeks we’ve been making more and more ticket types available. With the end of the financial year fast approaching this week, now is the perfect time to register for PyCon AU 2026\!
+
+### Team registration & group discounts
+
+Bringing the whole team to PyCon AU 2026? We’re looking forward to seeing you all!
+
+Email [contact@pycon.org.au](mailto:contact@pycon.org.au) to request a group order form and we can help your team register as a group with procurement or accounts payable payment terms.
+
+Alternatively, we'll also apply 5% off at checkout when registering 5 or more professional tickets online (and you still get a GST invoice for your records).
+
+### One day tickets
+
+You can now register for specific days of the conference. This is the perfect ticket type to attend specific specialist tracks, or if you just want to dip your toe in the water to experience a snippet of your first PyCon AU.
+
+You can register a one day ticket at either Professional, Enthusiast or Student levels.
+
+Specialist tracks run on specific days, while the main conference has talks on all three days of scheduled sessions. A one day ticket includes access to all talks on the day \- including specialist tracks and main conference.
+
+**Thursday** ([schedule](/schedule/thursday/)): Includes [Data & AI](/schedule/specialist-tracks/data-and-ai/) and [Platform Engineering](/schedule/specialist-tracks/platform-engineering/) tracks.
+
+**Friday** ([schedule](/schedule/friday/)): Includes [Cybersecurity](/schedule/specialist-tracks/cybersecurity/) and [Education](/schedule/specialist-tracks/education/) tracks.
+
+**Saturday** ([schedule](/schedule/saturday/)): Includes [Research Software Engineering](/schedule/specialist-tracks/research-software-engineering/) and [DevRel](/schedule/specialist-tracks/devrel/) tracks.
+
+<div class="flex justify-center">
+  <a href="https://pretix.eu/pyconau/2026/" class="btn-arrow btn-arrow--emerald inline-flex w-fit no-underline!">
+    <span>Register now</span>
+  </a>
+</div>
+
+### Educator tickets
+
+This year, we’re piloting a new ticket type specifically for teachers associated with primary or secondary schools. If you teach K-12 in Australia, New Zealand, or equivalent curricula such as IB, this ticket is for you. 
+
+The Educator ticket is a subsidised one day professional ticket for Friday 28 August including the Education specialist track and student showcase.
+
+*Note: Eligible teachers will be asked to identify their school or organisation during registration. Please register using your school's .edu.au or .nz email address*
+
+### Student Tickets
+
+A limited number of heavily subsidised tickets are now available for students, including school, university, and TAFE.  Tickets are available in both full conference (three days) and one day variants, and students are welcome to also register for workshops as well.
+
+*Note: To be eligible, you’ll need to bring your valid student ID or proof of enrolment when you check in.*
+
+<div class="flex justify-center">
+  <a href="https://pretix.eu/pyconau/2026/" class="btn-arrow btn-arrow--emerald inline-flex w-fit no-underline!">
+    <span>Register now</span>
+  </a>
+</div>
+
+### Workshops coming soon
+We're almost ready to announce our workshops for PyCon AU 2026. All attendees can attend workshops, but separate registration is required due to limited capacity.
+
+We welcome ALL ticket types (including Educators and Students) to attend workshops. So don't delay - register your ticket today and RSVP to workshops when they're announced... soon.


### PR DESCRIPTION
## Summary

Adds a news post announcing the newly available PyCon AU 2026 ticket types — one-day, educator and student tickets — with a centered "Register now" CTA linking to Pretix.

Branched off `main`; single new content file, no code changes. (Supersedes #117, which used the earlier branch name/title.)

## Test plan

- `/posts/all-ticket-types-now-available` renders with the correct title, date and category
- The "Register now" buttons are centered in the content column and link to the Pretix registration page
- `astro check` passes (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)