### PR TITLE
Credit GPN as sponsor of the Education specialist track

### DIFF
--- a/src/content/schedule-specialist-tracks/education.md
+++ b/src/content/schedule-specialist-tracks/education.md
@@ -3,6 +3,7 @@ title: "Education"
 pretalxTrack: "Education"
 shortDescription: "Teachers using python in the classroom 👍"
 date: 2026-08-28
+sponsor: gpn
 ---
 
 Learn about learning, teach about teaching, and educate about education! 


### PR DESCRIPTION
Adds `sponsor: gpn` to the Education specialist track frontmatter, crediting the Girls' Programming Network as the track sponsor.

This renders the "Track sponsor" branding (name + logo bubble) on the Education specialist track page, matching the existing pattern used by the Data & AI track (`sponsor: snowflake`).

- Slug `gpn` resolves to `src/content/sponsors/gpn.md`
- Logo asset `public/images/sponsors/GPN-Logo.svg` is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)