### PR TITLE
Chainguard cybersecurity sponsor + Student Showcase date updates

### DIFF
--- a/src/content/schedule-specialist-tracks/cybersecurity.md
+++ b/src/content/schedule-specialist-tracks/cybersecurity.md
@@ -3,6 +3,7 @@ title: "Cybersecurity"
 pretalxTrack: "Cybersecurity"
 shortDescription: "The Cybersecurity track focuses on security awareness, knowledge and practice for software developers, IT operations people, and cybersecurity specialists."
 date: 2026-08-28
+sponsor: chainguard
 ---
 
 In today's cyber threat landscape, security cannot be an afterthought.  Developers, operations, and management need to address cybersecurity at every stage of the technology lifecycle.

--- a/src/pages/cfp/student-showcase.astro
+++ b/src/pages/cfp/student-showcase.astro
@@ -90,15 +90,15 @@ export const nav = {
                 <td class="py-2">Apply for Financial Assistance. Applications will continue to be assessed until budget is exhausted.</td>
               </tr>
               <tr>
-                <td class="py-2 pr-4 align-top whitespace-nowrap">4 July</td>
-                <td class="py-2"><strong>Submissions for Student Showcase closes.</strong> (End of Term 2)</td>
+                <td class="py-2 pr-4 align-top whitespace-nowrap"><s>4 July</s> 26 July</td>
+                <td class="py-2"><strong>Submissions for Student Showcase closes.</strong><br /><span class="text-sm text-charcoal/70">Late submissions may be accepted, please email program@pycon.org.au as soon as possible.</span></td>
               </tr>
               <tr>
-                <td class="py-2 pr-4 align-top whitespace-nowrap">Mid-July</td>
+                <td class="py-2 pr-4 align-top whitespace-nowrap">Early August</td>
                 <td class="py-2">Notification of whether proposals have been accepted, not accepted, or waitlisted (early Term 3)</td>
               </tr>
               <tr>
-                <td class="py-2 pr-4 align-top whitespace-nowrap">22 July</td>
+                <td class="py-2 pr-4 align-top whitespace-nowrap">ASAP</td>
                 <td class="py-2">Accepted students must register for the conference.</td>
               </tr>
               <tr>
@@ -171,7 +171,7 @@ export const nav = {
             We aim to let everyone know the outcomes of their proposal (accept or decline) by mid-July in early Term 3.
           </p>
           <p>
-            <strong><em>If accepted, you will need to register for the conference promptly by 22 July 2026</em></strong>.
+            <strong><em>If accepted, you will need to register for the conference as soon as possible</em></strong>.
           </p>
 
           <h2>If you would like feedback on your proposal</h2>


### PR DESCRIPTION
## Summary
- Add Chainguard as the Cybersecurity specialist track sponsor, mirroring the Snowflake / Data & AI setup (links the `chainguard` sponsor slug to the track).
- Update the Student Showcase timeline: submission deadline extended to **26 July** (original 4 July struck through), added a late-submission contact note, notification moved to **Early August**, registration set to **ASAP**, and removed the "(End of Term 2)" qualifier.

## Test plan
- Verified both pages render correctly on the local dev server:
  - `/schedule/specialist-tracks/cybersecurity/` shows the Chainguard track-sponsor bubble and logo.
  - `/cfp/student-showcase/` shows the updated dates, strikethrough, and subtext.

🤖 Generated with [Claude Code](https://claude.com/claude-code)