### PR TITLE
Redirect legacy /program/* URLs to /schedule/*

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -42,7 +42,7 @@ export default defineConfig({
     // Legacy /program/* URLs (e.g. session links shared before the move to
     // /schedule/*) redirect to their /schedule/* equivalents.
     "/program/[code]": "/schedule/[code]",
-    "/program/specialist-tracks/[slug]": "/schedule/specialist-tracks/[slug]",
+    "/program/specialist-tracks/[...slug]": "/schedule/specialist-tracks/[...slug]",
     // Specialist track shortcuts
     "/data-and-ai": "/schedule/specialist-tracks/data-and-ai",
     "/education": "/schedule/specialist-tracks/education",

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -39,13 +39,17 @@ export default defineConfig({
   redirects: {
     "/student-showcase": "/cfp/student-showcase",
     "/workshops": "/schedule/workshops",
+    // Legacy /program/* URLs (e.g. session links shared before the move to
+    // /schedule/*) redirect to their /schedule/* equivalents.
+    "/program/[code]": "/schedule/[code]",
+    "/program/specialist-tracks/[slug]": "/schedule/specialist-tracks/[slug]",
     // Specialist track shortcuts
-    "/data-and-ai": "/program/specialist-tracks/data-and-ai",
-    "/education": "/program/specialist-tracks/education",
-    "/cybersecurity": "/program/specialist-tracks/cybersecurity",
-    "/devrel": "/program/specialist-tracks/devrel",
-    "/platform-engineering": "/program/specialist-tracks/platform-engineering",
-    "/research-software-engineering": "/program/specialist-tracks/research-software-engineering",
+    "/data-and-ai": "/schedule/specialist-tracks/data-and-ai",
+    "/education": "/schedule/specialist-tracks/education",
+    "/cybersecurity": "/schedule/specialist-tracks/cybersecurity",
+    "/devrel": "/schedule/specialist-tracks/devrel",
+    "/platform-engineering": "/schedule/specialist-tracks/platform-engineering",
+    "/research-software-engineering": "/schedule/specialist-tracks/research-software-engineering",
   },
   vite: {
     plugins: [tailwindcss()],


### PR DESCRIPTION
## Why

Session and specialist-track links were shared publicly (including via an email that went out) using `/program/<code>` URLs. The canonical routes live under `/schedule/*` and there is no `/program/` route at all, so those links currently **404**.

## What

Adds param-forwarding redirects to `astro.config.mjs`:

- `/program/[code]` → `/schedule/[code]` — catches the emailed session links
- `/program/specialist-tracks/[slug]` → `/schedule/specialist-tracks/[slug]`

Also fixes the existing specialist-track shortcut redirects (`/data-and-ai`, `/education`, etc.), which pointed at the non-existent `/program/specialist-tracks/*` targets, to point at `/schedule/*` instead.

## Notes

Astro forwards the named `[code]`/`[slug]` segment from source to destination, so a single entry covers every session code and track slug. The single-segment `[code]` pattern does not shadow the two-segment specialist-tracks path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)