### PR TITLE
Redirect legacy /program/*.png session graphics to /graphics/sessions/

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,8 +1,29 @@
 // @ts-check
+import { readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "astro/config";
 import mdx from "@astrojs/mdx";
 import tailwindcss from "@tailwindcss/vite";
 import sitemap from "@astrojs/sitemap";
+
+// Legacy /program/<code>-<variant>.png session graphic URLs were shared (e.g.
+// via email) before these moved to /graphics/sessions/. A param redirect can't
+// point at a public/ asset (Astro can't enumerate getStaticPaths for it), so
+// build one explicit static redirect per known session code instead. Codes are
+// the session content filenames.
+const sessionsDir = fileURLToPath(new URL("./src/content/sessions", import.meta.url));
+const sessionGraphicVariants = ["social", "og", "square"];
+const programGraphicRedirects = Object.fromEntries(
+  readdirSync(sessionsDir)
+    .filter((file) => file.endsWith(".md"))
+    .map((file) => file.replace(/\.md$/, ""))
+    .flatMap((code) =>
+      sessionGraphicVariants.map((variant) => [
+        `/program/${code}-${variant}.png`,
+        `/graphics/sessions/${code}-${variant}.png`,
+      ]),
+    ),
+);
 
 // Determine site URL based on environment
 // Reference: https://vercel.com/docs/projects/environment-variables/system-environment-variables
@@ -41,6 +62,7 @@ export default defineConfig({
     "/workshops": "/schedule/workshops",
     // Legacy /program/* URLs (e.g. session links shared before the move to
     // /schedule/*) redirect to their /schedule/* equivalents.
+    ...programGraphicRedirects,
     "/program/[code]": "/schedule/[code]",
     "/program/specialist-tracks/[...slug]": "/schedule/specialist-tracks/[...slug]",
     // Specialist track shortcuts


### PR DESCRIPTION
## Why

Session graphic links were shared (via email) with a `/program/` prefix, but the images live under `/graphics/sessions/`.

## What

Production deploys to **GitHub Pages** (static; no redirect engine), so this uses Astro's built-in static redirects like the other `/program/*` URLs.

A param redirect can't be used here: the destination is a `public/` asset with no route, so Astro can't enumerate `getStaticPaths` and the build fails. Instead, `astro.config.mjs` generates one explicit **static** redirect per known session code (read from `src/content/sessions/`) for each graphic variant. Exact static entries take precedence over the `/program/[code]` session redirect.

## Verified locally with `astro build`

- Build completes (158 pages), no `getStaticPaths` error.
- Emits redirect stubs from `/program/<code>-<variant>.png` to `/graphics/sessions/<code>-<variant>.png`.
- Non-`.png` `/program/*` URLs still redirect to `/schedule/*` — no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)