### PR TITLE
Make the schedule usable on a phone: agenda layout below 768px

### DIFF
--- a/src/components/schedule/AgendaList.astro
+++ b/src/components/schedule/AgendaList.astro
@@ -128,17 +128,19 @@ const { groups, speakerMap, trackSlugs } = Astro.props;
                     {room && !entry.isFullWidth && (
                       <span class="agenda-card__meta">{room}</span>
                     )}
-                    {isNotYetAnnounced ? (
-                      <span class="agenda-card__speakers">(Session not yet published)</span>
-                    ) : (
-                      speakerNames && (
+                    {/* Bottom row: speaker on the left, note on the right,
+                        matching the desktop card. */}
+                    <span class="agenda-card__footer">
+                      {isNotYetAnnounced ? (
+                        <span class="agenda-card__speakers">(Session not yet published)</span>
+                      ) : (
                         <span class="agenda-card__speakers">{speakerNames}</span>
-                      )
-                    )}
-                    {/* Workshops are ticketed separately from the conference. */}
-                    {session.data.type === "workshop" && (
-                      <span class="agenda-card__note">Separate registration</span>
-                    )}
+                      )}
+                      {/* Workshops are ticketed separately from the conference. */}
+                      {session.data.type === "workshop" && (
+                        <span class="agenda-card__note">Separate registration</span>
+                      )}
+                    </span>
                   </div>
 
                   {/* Reserved for the Phase 3 favourite star. Renders as empty

--- a/src/components/schedule/AgendaList.astro
+++ b/src/components/schedule/AgendaList.astro
@@ -135,6 +135,10 @@ const { groups, speakerMap, trackSlugs } = Astro.props;
                         <span class="agenda-card__speakers">{speakerNames}</span>
                       )
                     )}
+                    {/* Workshops are ticketed separately from the conference. */}
+                    {session.data.type === "workshop" && (
+                      <span class="agenda-card__note">Separate registration</span>
+                    )}
                   </div>
 
                   {/* Reserved for the Phase 3 favourite star. Renders as empty

--- a/src/components/schedule/AgendaList.astro
+++ b/src/components/schedule/AgendaList.astro
@@ -38,12 +38,9 @@ const { groups, speakerMap, trackSlugs } = Astro.props;
             const isNotYetAnnounced = tags?.includes("not-yet-announced");
             const trackColor = getTrackColor(track);
 
-            // A session running past its own group shows the time it ends
-            // rather than a duration - "until 3:40pm" is easier to reason
-            // about mid-conference than "100 min".
-            const timeText = entry.spansMultipleGroups
-              ? `${formatAgendaTime(start)}–${formatAgendaTime(end)}`
-              : `${entry.durationMinutes} min`;
+            // Time range, matching the desktop card. Duration is not shown -
+            // the start and end times are what people reason about.
+            const timeText = `${formatAgendaTime(start)} – ${formatAgendaTime(end)}`;
 
             const speakerNames = (session.data.speakers || [])
               .map((c: string) => speakerMap.get(c))
@@ -67,20 +64,24 @@ const { groups, speakerMap, trackSlugs } = Astro.props;
               );
             }
 
-            // Continuation cards are context for a block already under way:
-            // subordinate treatment, no star slot, no speakers, no track header.
+            // Continuation cards keep the session's own styling - same track
+            // background - so a block already under way reads as the same
+            // session, not a different kind of thing. They carry no star slot
+            // (favouriting is per-session, not per-appearance), no speakers and
+            // no track header.
             if (entry.isContinuation) {
               return (
-                <a href={`/schedule/${code}`} class="agenda-continuation">
-                  <span class="agenda-continuation__marker" aria-hidden="true">▸</span>
-                  <span class="agenda-continuation__body">
-                    <span class="agenda-continuation__title">{title}</span>
-                    <span class="agenda-continuation__meta">
-                      <span class="agenda-continuation__label">continues</span>
-                      {room && !entry.isFullWidth && <> · {room}</>}
-                      <> · until {formatAgendaTime(end)}</>
+                <a
+                  href={`/schedule/${code}`}
+                  class="agenda-card agenda-card--continuation"
+                  style={`background-color: ${trackColor.bg}; color: ${trackColor.text};`}
+                >
+                  <div class="agenda-card__body">
+                    <span class="agenda-card__title">{title}</span>
+                    <span class="agenda-card__meta">
+                      {room ? `Continues in ${room}` : "Continues"}
                     </span>
-                  </span>
+                  </div>
                 </a>
               );
             }
@@ -120,10 +121,13 @@ const { groups, speakerMap, trackSlugs } = Astro.props;
                   style={`background-color: ${trackColor.bg}; color: ${trackColor.text};`}
                 >
                   <div class="agenda-card__body">
+                    {/* Time first, then title, then speakers - the desktop
+                        card's order. */}
+                    <span class="agenda-card__time">{timeText}</span>
                     <span class="agenda-card__title">{title}</span>
-                    <span class="agenda-card__meta">
-                      {room && !entry.isFullWidth && <>{room} · </>}{timeText}
-                    </span>
+                    {room && !entry.isFullWidth && (
+                      <span class="agenda-card__meta">{room}</span>
+                    )}
                     {isNotYetAnnounced ? (
                       <span class="agenda-card__speakers">(Session not yet published)</span>
                     ) : (

--- a/src/components/schedule/AgendaList.astro
+++ b/src/components/schedule/AgendaList.astro
@@ -1,0 +1,148 @@
+---
+import type { AgendaGroup } from "../../utils/schedule";
+import type { Person } from "../../utils/schedule";
+import {
+  formatAgendaTime,
+  getTrackColor,
+} from "../../utils/schedule";
+
+interface Props {
+  groups: AgendaGroup[];
+  speakerMap: Map<string, Person>;
+  trackSlugs: Set<string>;
+}
+
+const { groups, speakerMap, trackSlugs } = Astro.props;
+---
+
+{groups.length > 0 && (
+  <div class="agenda" aria-label="Schedule">
+    {groups.map((group) => (
+      <section class="agenda-group">
+        <h2 class="agenda-group__time">{group.label}</h2>
+
+        <div class="agenda-group__entries">
+          {group.entries.map((entry) => {
+            const { session } = entry;
+            const {
+              code,
+              title,
+              room,
+              start,
+              end,
+              track,
+              trackName,
+              tags,
+            } = session.data;
+
+            const isNotYetAnnounced = tags?.includes("not-yet-announced");
+            const trackColor = getTrackColor(track);
+
+            // A session running past its own group shows the time it ends
+            // rather than a duration - "until 3:40pm" is easier to reason
+            // about mid-conference than "100 min".
+            const timeText = entry.spansMultipleGroups
+              ? `${formatAgendaTime(start)}–${formatAgendaTime(end)}`
+              : `${entry.durationMinutes} min`;
+
+            const speakerNames = (session.data.speakers || [])
+              .map((c: string) => speakerMap.get(c))
+              .filter(Boolean)
+              .map((s: any) => s.data.name)
+              .join(", ");
+
+            const trackHref =
+              track && trackSlugs.has(track)
+                ? `/schedule/specialist-tracks/${track}`
+                : null;
+
+            if (entry.isBreak) {
+              return (
+                <div class="agenda-break">
+                  <span class="agenda-break__title">{title}</span>
+                  <span class="agenda-break__time">
+                    {formatAgendaTime(start)}–{formatAgendaTime(end)}
+                  </span>
+                </div>
+              );
+            }
+
+            // Continuation cards are context for a block already under way:
+            // subordinate treatment, no star slot, no speakers, no track header.
+            if (entry.isContinuation) {
+              return (
+                <a href={`/schedule/${code}`} class="agenda-continuation">
+                  <span class="agenda-continuation__marker" aria-hidden="true">▸</span>
+                  <span class="agenda-continuation__body">
+                    <span class="agenda-continuation__title">{title}</span>
+                    <span class="agenda-continuation__meta">
+                      <span class="agenda-continuation__label">continues</span>
+                      {room && !entry.isFullWidth && <> · {room}</>}
+                      <> · until {formatAgendaTime(end)}</>
+                    </span>
+                  </span>
+                </a>
+              );
+            }
+
+            const CardTag = isNotYetAnnounced ? "div" : "a";
+
+            return (
+              <div class="agenda-item">
+                {entry.showTrackHeader && trackName && (
+                  <div class="agenda-track-header">
+                    <svg
+                      class="agenda-track-icon"
+                      style={`fill: ${trackColor.bg};`}
+                      xmlns="http://www.w3.org/2000/svg"
+                      width="17.935"
+                      height="17.936"
+                      viewBox="0 0 17.935 17.936"
+                      aria-hidden="true"
+                    >
+                      <g transform="translate(0 10)">
+                        <g transform="translate(0 -10)">
+                          <path d="M8.968,17.936h0A8.968,8.968,0,0,0,0,8.968,8.968,8.968,0,0,0,8.968,0a8.968,8.968,0,0,0,8.968,8.968,8.968,8.968,0,0,0-8.968,8.968"/>
+                        </g>
+                      </g>
+                    </svg>
+                    {trackHref ? (
+                      <a href={trackHref} class="agenda-track-name agenda-track-name--link">{trackName}</a>
+                    ) : (
+                      <span class="agenda-track-name">{trackName}</span>
+                    )}
+                  </div>
+                )}
+
+                <CardTag
+                  href={isNotYetAnnounced ? undefined : `/schedule/${code}`}
+                  class={`agenda-card${isNotYetAnnounced ? " agenda-card--inert" : ""}`}
+                  style={`background-color: ${trackColor.bg}; color: ${trackColor.text};`}
+                >
+                  <div class="agenda-card__body">
+                    <span class="agenda-card__title">{title}</span>
+                    <span class="agenda-card__meta">
+                      {room && !entry.isFullWidth && <>{room} · </>}{timeText}
+                    </span>
+                    {isNotYetAnnounced ? (
+                      <span class="agenda-card__speakers">(Session not yet published)</span>
+                    ) : (
+                      speakerNames && (
+                        <span class="agenda-card__speakers">{speakerNames}</span>
+                      )
+                    )}
+                  </div>
+
+                  {/* Reserved for the Phase 3 favourite star. Renders as empty
+                      space, not a dead control - dropping a 44px star in here
+                      must cause no reflow. */}
+                  <div class="agenda-card__star-slot" aria-hidden="true"></div>
+                </CardTag>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+    ))}
+  </div>
+)}

--- a/src/components/schedule/AgendaList.astro
+++ b/src/components/schedule/AgendaList.astro
@@ -38,6 +38,12 @@ const { groups, speakerMap, trackSlugs } = Astro.props;
             const isNotYetAnnounced = tags?.includes("not-yet-announced");
             const trackColor = getTrackColor(track);
 
+            // Ticketed separately from the conference. Workshops are the only
+            // session type in the collection that is; Sunday's sprints are
+            // included with a contributor ticket and live on their own
+            // hand-built page rather than as sessions.
+            const needsSeparateRegistration = session.data.type === "workshop";
+
             // Time range, matching the desktop card. Duration is not shown -
             // the start and end times are what people reason about.
             const timeText = `${formatAgendaTime(start)} – ${formatAgendaTime(end)}`;
@@ -76,11 +82,13 @@ const { groups, speakerMap, trackSlugs } = Astro.props;
                   class="agenda-card agenda-card--continuation"
                   style={`background-color: ${trackColor.bg}; color: ${trackColor.text};`}
                 >
-                  <div class="agenda-card__body">
-                    <span class="agenda-card__title">{title}</span>
-                    <span class="agenda-card__meta">
-                      {room ? `Continues in ${room}` : "Continues"}
-                    </span>
+                  <div class="agenda-card__row">
+                    <div class="agenda-card__primary">
+                      <span class="agenda-card__title">{title}</span>
+                      <span class="agenda-card__meta">
+                        {room ? `Continues in ${room}` : "Continues"}
+                      </span>
+                    </div>
                   </div>
                 </a>
               );
@@ -120,33 +128,56 @@ const { groups, speakerMap, trackSlugs } = Astro.props;
                   class={`agenda-card${isNotYetAnnounced ? " agenda-card--inert" : ""}`}
                   style={`background-color: ${trackColor.bg}; color: ${trackColor.text};`}
                 >
-                  <div class="agenda-card__body">
-                    {/* Time first, then title, then speakers - the desktop
-                        card's order. */}
-                    <span class="agenda-card__time">{timeText}</span>
-                    <span class="agenda-card__title">{title}</span>
-                    {room && !entry.isFullWidth && (
-                      <span class="agenda-card__meta">{room}</span>
-                    )}
-                    {/* Bottom row: speaker on the left, note on the right,
-                        matching the desktop card. */}
-                    <span class="agenda-card__footer">
+                  {/* Two rows, each a flex pair. Top: time + title, with the
+                      star beside them. Bottom: room + speakers, with any
+                      registration note on the right. The star sits only
+                      against the top row rather than spanning the card's full
+                      height, so the bottom row keeps the card's full width. */}
+                  <div class="agenda-card__row">
+                    <div class="agenda-card__primary">
+                      <span class="agenda-card__time">{timeText}</span>
+                      <span class="agenda-card__title">{title}</span>
+                    </div>
+
+                    {/* Reserved for the Phase 3 favourite star. Renders as
+                        empty space, not a dead control - dropping a 44px star
+                        in here must cause no reflow. */}
+                    <div class="agenda-card__star-slot" aria-hidden="true"></div>
+                  </div>
+
+                  <div class="agenda-card__row agenda-card__row--secondary">
+                    <div class="agenda-card__secondary">
+                      {room && !entry.isFullWidth && (
+                        <span class="agenda-card__meta">{room}</span>
+                      )}
                       {isNotYetAnnounced ? (
                         <span class="agenda-card__speakers">(Session not yet published)</span>
                       ) : (
-                        <span class="agenda-card__speakers">{speakerNames}</span>
+                        speakerNames && (
+                          <span class="agenda-card__speakers">{speakerNames}</span>
+                        )
                       )}
-                      {/* Workshops are ticketed separately from the conference. */}
-                      {session.data.type === "workshop" && (
-                        <span class="agenda-card__note">Separate registration</span>
-                      )}
-                    </span>
-                  </div>
+                    </div>
 
-                  {/* Reserved for the Phase 3 favourite star. Renders as empty
-                      space, not a dead control - dropping a 44px star in here
-                      must cause no reflow. */}
-                  <div class="agenda-card__star-slot" aria-hidden="true"></div>
+                    {/* Workshops and sprints are ticketed separately from the
+                        conference. Material Symbols "info", inlined rather
+                        than loaded as a font so it costs no request and
+                        inherits the card's text colour. */}
+                    {needsSeparateRegistration && (
+                      <span class="agenda-card__note">
+                        <svg
+                          class="agenda-card__note-icon"
+                          xmlns="http://www.w3.org/2000/svg"
+                          viewBox="0 -960 960 960"
+                          fill="currentColor"
+                          aria-hidden="true"
+                        >
+                          <path d="M440-280h80v-240h-80v240Zm40-320q17 0 28.5-11.5T520-640q0-17-11.5-28.5T480-680q-17 0-28.5 11.5T440-640q0 17 11.5 28.5T480-600Zm0 520q-83 0-156-31.5T197-197q-54-54-85.5-127T80-480q0-83 31.5-156T197-763q54-54 127-85.5T480-880q83 0 156 31.5T763-763q54 54 85.5 127T880-480q0 83-31.5 156T763-197q-54 54-127 85.5T480-80Zm0-80q134 0 227-93t93-227q0-134-93-227t-227-93q-134 0-227 93t-93 227q0 134 93 227t227 93Zm0-320Z"/>
+                        </svg>
+                        <span>Separate registration</span>
+                      </span>
+                    )}
+                  </div>
                 </CardTag>
               </div>
             );

--- a/src/pages/schedule/[code].astro
+++ b/src/pages/schedule/[code].astro
@@ -8,6 +8,8 @@ import {
   getPeopleByCode,
   getTrackBySlug,
   formatSessionDateTime,
+  getConferenceDays,
+  CONFERENCE_TIMEZONE,
 } from "../../utils/schedule";
 import { marked } from "marked";
 
@@ -68,17 +70,33 @@ const ogDescription = [
   .filter(Boolean)
   .join(" • ");
 
-// Build breadcrumb
+// Build breadcrumb: Home > Schedule > Thursday. The day's slug is the
+// lowercased weekday in conference time, matching [day].astro's
+// getStaticPaths, and is only added when that day actually has a page to
+// link to. The track is not a breadcrumb - it's linked from the header's
+// meta row instead.
+const conferenceDays = await getConferenceDays();
+const sessionDay = start
+  ? start.toLocaleDateString("en-AU", {
+      weekday: "long",
+      timeZone: CONFERENCE_TIMEZONE,
+    })
+  : null;
+
 const breadcrumbs = [
   { label: "Home", href: "/" },
   { label: "Schedule", href: "/schedule" },
 ];
-if (trackData) {
+if (sessionDay && conferenceDays.includes(sessionDay.toLowerCase())) {
   breadcrumbs.push({
-    label: trackData.data.title,
-    href: `/schedule/specialist-tracks/${track}`,
+    label: sessionDay,
+    href: `/schedule/${sessionDay.toLowerCase()}`,
   });
 }
+
+// Link the track name in the header when it resolves to a specialist track
+// page. Sessions whose track has no page (e.g. Main Conference) stay plain.
+const trackHref = trackData ? `/schedule/specialist-tracks/${track}` : null;
 ---
 
 <Base title={title} ogImage={ogImage} description={ogDescription}>
@@ -123,7 +141,13 @@ if (trackData) {
           </h1>
 
           <div class="fadeInUp flex flex-wrap lg:flex-nowrap items-center justify-between border-t-2 border-emerald text-sm font-semibold text-emerald mt-7 pt-1 gap-2">
-            {displayTrackName && <span>{displayTrackName}</span>}
+            {displayTrackName && (
+              trackHref ? (
+                <a href={trackHref} class="underline hover:no-underline">{displayTrackName}</a>
+              ) : (
+                <span>{displayTrackName}</span>
+              )
+            )}
             {room && <span>{room}</span>}
             {dateTimeString && (
               <span>{dateTimeString}</span>

--- a/src/pages/schedule/[code].astro
+++ b/src/pages/schedule/[code].astro
@@ -118,7 +118,7 @@ if (trackData) {
             )}
           </div>
 
-          <h1 class="fadeInUp text-5xl font-serif font-normal tracking-[-0.02em] text-center w-[95%] mx-auto pt-5">
+          <h1 class="fadeInUp text-3xl md:text-5xl font-serif font-normal tracking-[-0.02em] text-center w-full md:w-[95%] mx-auto pt-5">
             {title}
           </h1>
 
@@ -147,17 +147,17 @@ if (trackData) {
           ))}
 
           {sponsorData && (
-            <div class="fadeInUp flex justify-between items-center gap-6 bg-white rounded-[3.125rem] py-5 px-14 mt-14">
+            <div class="fadeInUp flex flex-col sm:flex-row justify-between sm:items-center gap-6 bg-white rounded-[2rem] md:rounded-[3.125rem] py-5 px-6 md:px-14 mt-14">
               <div>
                 <span class="block text-sm tracking-[0.01em] text-charcoal">
                   This session is presented by
                 </span>
-                <h3 class="text-3xl font-semibold text-charcoal">{sponsorData.data.name}</h3>
+                <h3 class="text-2xl md:text-3xl font-semibold text-charcoal">{sponsorData.data.name}</h3>
               </div>
               <img
                 src={`/images/sponsors/${sponsorData.data.logo}`}
                 alt={sponsorData.data.name}
-                class="h-16 w-auto max-w-[40%] object-contain"
+                class="h-16 w-auto max-w-full sm:max-w-[40%] object-contain self-start sm:self-auto"
               />
             </div>
           )}

--- a/src/pages/schedule/[code].astro
+++ b/src/pages/schedule/[code].astro
@@ -94,9 +94,16 @@ if (sessionDay && conferenceDays.includes(sessionDay.toLowerCase())) {
   });
 }
 
-// Link the track name in the header when it resolves to a specialist track
-// page. Sessions whose track has no page (e.g. Main Conference) stay plain.
-const trackHref = trackData ? `/schedule/specialist-tracks/${track}` : null;
+// Link the track name in the header when it resolves to a page. Specialist
+// tracks have their own page; workshops aren't a specialist track (no track
+// file) but do have a listing page, so they're matched on session type.
+// Anything else - Main Conference, untracked sessions - stays plain text
+// rather than becoming a dead link.
+const trackHref = trackData
+  ? `/schedule/specialist-tracks/${track}`
+  : type === "workshop"
+    ? "/schedule/workshops"
+    : null;
 ---
 
 <Base title={title} ogImage={ogImage} description={ogDescription}>

--- a/src/pages/schedule/[day].astro
+++ b/src/pages/schedule/[day].astro
@@ -280,7 +280,18 @@ const trackSlugs = new Set(
                                 <span class="schedule-event-footer">
                                   <span class="schedule-event-presenter">{speakerNames}</span>
                                   {ps.session.data.type === "workshop" && (
-                                    <span class="schedule-event-note">Separate registration</span>
+                                    <span class="schedule-event-note">
+                                      <svg
+                                        class="schedule-event-note-icon"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                        viewBox="0 -960 960 960"
+                                        fill="currentColor"
+                                        aria-hidden="true"
+                                      >
+                                        <path d="M440-280h80v-240h-80v240Zm40-320q17 0 28.5-11.5T520-640q0-17-11.5-28.5T480-680q-17 0-28.5 11.5T440-640q0 17 11.5 28.5T480-600Zm0 520q-83 0-156-31.5T197-197q-54-54-85.5-127T80-480q0-83 31.5-156T197-763q54-54 127-85.5T480-880q83 0 156 31.5T763-763q54 54 85.5 127T880-480q0 83-31.5 156T763-197q-54 54-127 85.5T480-80Zm0-80q134 0 227-93t93-227q0-134-93-227t-227-93q-134 0-227 93t-93 227q0 134 93 227t227 93Zm0-320Z"/>
+                                      </svg>
+                                      <span>Separate registration</span>
+                                    </span>
                                   )}
                                 </span>
                               </div>

--- a/src/pages/schedule/[day].astro
+++ b/src/pages/schedule/[day].astro
@@ -2,12 +2,14 @@
 import { getCollection } from "astro:content";
 import Footer from "../../components/Footer.astro";
 import Header from "../../components/Header.astro";
+import AgendaList from "../../components/schedule/AgendaList.astro";
 import DayTabs from "../../components/schedule/DayTabs.astro";
 import Base from "../../layouts/Base.astro";
 import {
   getConferenceDays,
   getSessionsByDay,
   getScheduleForGrid,
+  getScheduleForAgenda,
   getDayDate,
   getTrackColor,
   getPeopleByCode,
@@ -26,6 +28,9 @@ const dayCapitalized = day.charAt(0).toUpperCase() + day.slice(1);
 
 // Get sessions for grid layout
 const { rooms, rows, layout } = await getScheduleForGrid(day);
+// Agenda groups for the mobile layout (< 768px). Both layouts render into the
+// same document and CSS chooses between them - see .claude/plans §6.1.
+const agendaGroups = await getScheduleForAgenda(day);
 const dateString = await getDayDate(day);
 const allDays = await getConferenceDays();
 
@@ -286,6 +291,17 @@ const trackSlugs = new Set(
         </div>
       </div>
     )}
+
+    <!-- Agenda list: the mobile layout, shown below 768px in place of the grid -->
+    <div class="agenda-wrapper">
+      <div class="container">
+        <AgendaList
+          groups={agendaGroups}
+          speakerMap={speakerMap}
+          trackSlugs={trackSlugs}
+        />
+      </div>
+    </div>
 
     {rows.length === 0 && (
       <div class="container">

--- a/src/pages/schedule/[day].astro
+++ b/src/pages/schedule/[day].astro
@@ -272,11 +272,17 @@ const trackSlugs = new Set(
                               <div>
                                 <span class="schedule-event-time">{timeStr}</span>
                               </div>
-                              <div>
+                              <div class="w-full">
                                 <span class="schedule-event-topic">{ps.session.data.title}</span>
-                                {speakerNames && (
+                                {/* Workshops are ticketed separately from the
+                                    conference, so the card says so inline with
+                                    the speaker name. */}
+                                <span class="schedule-event-footer">
                                   <span class="schedule-event-presenter">{speakerNames}</span>
-                                )}
+                                  {ps.session.data.type === "workshop" && (
+                                    <span class="schedule-event-note">Separate registration</span>
+                                  )}
+                                </span>
                               </div>
                             </EventTag>
                           </div>

--- a/src/pages/schedule/[day].astro
+++ b/src/pages/schedule/[day].astro
@@ -85,7 +85,7 @@ const trackSlugs = new Set(
     <!-- Schedule Grid -->
     {rows.length > 0 && (
       <div
-        class="fadeInUp schedule-wrapper"
+        class="fadeInUp schedule-wrapper schedule-wrapper--has-agenda"
         style={`--schedule-room-count: ${rooms.length};`}
         data-rooms={rooms.length}
         data-layout={layout}

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -579,6 +579,10 @@ ul.sub-menu {
   --schedule-slot-height: 160px;
   /* Calculate min-width based on room count for mobile scrolling */
   --schedule-mobile-width: calc(80px + (var(--schedule-room-count) * 320px));
+  /* Column gutter. The --span-* width calculations below are derived from this
+     rather than repeating a literal, so a gutter change at any breakpoint can
+     never leave spanning plenaries and breaks misaligned. */
+  --schedule-gutter: 1.5rem;
 }
 
 /* Simple layout: 60-minute slots with shorter height */
@@ -649,7 +653,8 @@ ul.sub-menu {
 }
 
 .schedule {
-  @apply grid gap-x-6 border-y border-[#DBDBDB] mt-10 px-5;
+  @apply grid border-y border-[#DBDBDB] mt-10 px-5;
+  column-gap: var(--schedule-gutter);
   /* Desktop: time column (80px) + flexible room columns */
   grid-template-columns: 80px repeat(var(--schedule-room-count), 1fr);
   /* Mobile: fixed widths for scrolling */
@@ -691,6 +696,88 @@ ul.sub-menu {
   }
 }
 
+/* Tablet grid (768-1023px).
+
+   The 768px agenda breakpoint keeps the grid alive for tablets, but the grid
+   held its fixed --schedule-mobile-width canvas until 1024px, so a tablet
+   scrolled sideways exactly like a phone. Let the columns divide the available
+   width instead of taking a fixed 320px each.
+
+   The gutter shrinks here to buy column width; --schedule-gutter drives the
+   --span-* calculations too, so spanning plenaries and multi-room breaks stay
+   aligned with the columns they span. */
+@media (min-width: 768px) and (max-width: 1023.98px) {
+  .schedule-wrapper {
+    --schedule-gutter: 0.75rem;
+    overflow-x: hidden;
+  }
+
+  .schedule-title,
+  .schedule {
+    width: auto;
+    min-width: 0;
+    margin-left: auto;
+    margin-right: auto;
+    /* Narrower time column: labels are short and every pixel here is a pixel
+       the room columns don't get. */
+    grid-template-columns: 56px repeat(var(--schedule-room-count), 1fr);
+  }
+
+  .schedule-title {
+    column-gap: var(--schedule-gutter);
+  }
+
+  .schedule-title__room {
+    @apply px-1 py-2 text-sm;
+  }
+
+  .schedule-event {
+    @apply px-2 py-1.5;
+    font-size: 0.6875rem;
+    line-height: 1.25;
+    /* Cards carry an inline pixel height from the grid geometry; without this
+       a long title at ~155px per column spills past the card's rounded edge. */
+    overflow: hidden;
+  }
+
+  /* Titles wrap to at most three lines, then ellipsis - the title is what
+     people scan by, so it gets the space, but an unclamped one can outgrow
+     the card at this column width. The card is a flex column, so the clamp
+     goes on the block wrapping the title, not on the inline span. */
+  .schedule-event > div:last-child {
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  .schedule-event-topic {
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  .schedule-event-time {
+    font-size: 0.625rem;
+  }
+
+  .schedule-break-title,
+  .schedule-break-time {
+    font-size: 0.6875rem;
+  }
+
+  .schedule-track-name {
+    font-size: 0.625rem;
+  }
+}
+
+/* Four-room days (Saturday) are the pressure case at ~155px per column.
+   Suppressing speaker names below 900px keeps titles readable. */
+@media (min-width: 768px) and (max-width: 899.98px) {
+  .schedule-wrapper[data-rooms="4"] .schedule-event-presenter {
+    display: none;
+  }
+}
+
 .schedule .time {
   @apply text-charcoal font-semibold tracking-[0.01rem] pt-2;
   @apply sticky left-0 z-30 bg-stone;
@@ -715,27 +802,27 @@ ul.sub-menu {
 
 .schedule-event-wrapper--fullwidth {
   /* Full-width sessions span across all room columns */
-  /* Width = (roomCount * 100%) + ((roomCount - 1) * gap) */
+  /* Width = (roomCount * 100%) + ((roomCount - 1) * gutter) */
   @apply z-20;
-  width: calc(var(--schedule-room-count) * 100% + (var(--schedule-room-count) - 1) * 1.5rem);
+  width: calc(var(--schedule-room-count) * 100% + (var(--schedule-room-count) - 1) * var(--schedule-gutter));
 }
 
 .schedule-event-wrapper--span-2 {
-  /* Span 2 columns + 1 gap */
+  /* Span 2 columns + 1 gutter */
   z-index: 15;
-  width: calc(200% + 1.5rem);
+  width: calc(200% + var(--schedule-gutter));
 }
 
 .schedule-event-wrapper--span-3 {
-  /* Span 3 columns + 2 gaps */
+  /* Span 3 columns + 2 gutters */
   z-index: 15;
-  width: calc(300% + 3rem);
+  width: calc(300% + 2 * var(--schedule-gutter));
 }
 
 .schedule-event-wrapper--span-4 {
-  /* Span 4 columns + 3 gaps */
+  /* Span 4 columns + 3 gutters */
   z-index: 15;
-  width: calc(400% + 4.5rem);
+  width: calc(400% + 3 * var(--schedule-gutter));
 }
 
 .schedule-event-track-header {
@@ -746,6 +833,30 @@ ul.sub-menu {
   /* Position above the session card */
   top: -24px;
   left: 0;
+  right: 0;
+  /* The header slot is a fixed 24px, so a label that wraps has its second line
+     clipped behind the card below it. Keep it on one line and let the name
+     ellipsis instead. */
+  white-space: nowrap;
+}
+
+/* Long track names ("Research Software Engineering" needs ~267px) outgrow the
+   column below roughly 1290px, where the 4-room Saturday grid gives each
+   column ~266px. Step the label down a size there rather than let it clip. */
+@media (max-width: 1289.98px) {
+  .schedule-track-name {
+    font-size: 0.75rem;
+    letter-spacing: -0.01em;
+  }
+
+  .schedule-event-track-header {
+    gap: 0.375rem;
+  }
+
+  .schedule-track-icon {
+    width: 14px;
+    height: 14px;
+  }
 }
 
 .schedule-track-icon {
@@ -756,6 +867,8 @@ ul.sub-menu {
 
 .schedule-track-name {
   @apply font-semibold text-[#747474];
+  @apply overflow-hidden text-ellipsis;
+  min-width: 0;
 }
 
 .schedule-track-name--link {
@@ -811,6 +924,209 @@ ul.sub-menu {
 
 .schedule-break-time {
   @apply block text-charcoal;
+}
+
+/* ==========================================================================
+   Agenda list - the mobile schedule layout (< 768px)
+
+   A second layout over the same session data, not a restyling of the grid.
+   The grid's premise is spatial comparison across rooms, which needs
+   horizontal room a phone doesn't have; below 768px the grid is hidden and
+   this single chronological column replaces it. Both render into the same
+   document - CSS alone chooses between them.
+   ========================================================================== */
+
+.agenda-wrapper {
+  @apply mt-10;
+}
+
+/* The layout swap. Below 768px the agenda replaces the grid entirely; from
+   768px up the grid returns and the agenda is removed from the document flow.
+   No JS branch and no user-agent sniffing - the site is pre-rendered, so a JS
+   decision would flash the wrong layout on load. */
+@media (min-width: 768px) {
+  .agenda-wrapper {
+    display: none;
+  }
+}
+
+@media (max-width: 767.98px) {
+  .schedule-wrapper {
+    display: none;
+  }
+}
+
+.agenda {
+  @apply flex flex-col;
+  /* The gap between groups does as much wayfinding work as the type does:
+     it is what makes a block read as one time slot rather than a continuous
+     stream of cards. */
+  gap: 2.5rem;
+}
+
+.agenda-group {
+  @apply flex flex-col;
+}
+
+/* Sticky time heading. On a 34-session day the most common failure is losing
+   track of what time you're looking at; this is what prevents it. It replaces
+   the grid's sticky left time column, meaningless without a horizontal axis. */
+.agenda-group__time {
+  @apply sticky top-0 z-20 bg-stone;
+  @apply font-serif text-charcoal;
+  /* Out-ranks the session titles beneath it - it is the primary wayfinding
+     element on the page, and three or four stacked cards can otherwise let
+     the titles dominate through sheer mass. */
+  font-size: 1.75rem;
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  margin-bottom: 0.75rem;
+  border-bottom: 2px solid #313131;
+}
+
+.agenda-group__entries {
+  /* Strictly one column. Nothing sits side by side at any width under 768px -
+     the full width is what buys each card a readable title, its room and the
+     star slot without compression. */
+  @apply flex flex-col;
+  gap: 0.625rem;
+}
+
+.agenda-item {
+  @apply relative flex flex-col;
+}
+
+.agenda-track-header {
+  @apply flex items-center gap-2;
+  @apply font-sans font-semibold text-sm;
+  margin-bottom: 0.25rem;
+}
+
+.agenda-track-icon {
+  @apply flex-shrink-0;
+  width: 14px;
+  height: 14px;
+}
+
+.agenda-track-name {
+  @apply font-semibold text-[#747474] text-xs uppercase tracking-[0.08em];
+}
+
+.agenda-track-name--link {
+  @apply no-underline cursor-pointer transition-colors;
+}
+
+.agenda-track-name--link:hover {
+  @apply text-charcoal underline;
+}
+
+.agenda-card {
+  @apply relative flex items-start justify-between gap-2;
+  @apply bg-white text-charcoal font-sans no-underline;
+  @apply rounded-[1.25rem];
+  padding: 0.875rem 1rem;
+  /* WCAG 2.5.8 / iOS HIG minimum tap target. */
+  min-height: 44px;
+}
+
+.agenda-card--inert {
+  @apply pointer-events-none;
+}
+
+.agenda-card__body {
+  @apply flex flex-col min-w-0;
+  gap: 0.125rem;
+}
+
+.agenda-card__title {
+  @apply block font-extrabold;
+  font-size: 1rem;
+  line-height: 1.25;
+}
+
+.agenda-card__meta {
+  @apply block font-medium;
+  font-size: 0.8125rem;
+  line-height: 1.3;
+  opacity: 0.85;
+}
+
+.agenda-card__speakers {
+  @apply block;
+  font-size: 0.8125rem;
+  line-height: 1.3;
+  opacity: 0.85;
+}
+
+/* Reserved space for the Phase 3 favourite star. Deliberately empty rather
+   than a visible-but-dead star, which invites tapping and disappoints. The
+   text column is sized around it so dropping a star in causes zero reflow. */
+.agenda-card__star-slot {
+  @apply flex-shrink-0;
+  width: 44px;
+  height: 44px;
+  /* Pull level with the title's cap height rather than the card padding. */
+  margin: -0.375rem -0.5rem 0 0;
+}
+
+/* Continuation card: a session already under way, repeated so it isn't
+   invisible from its start time onward. Visibly subordinate to a real card -
+   if it reads as an identical duplicate, the design has failed. */
+.agenda-continuation {
+  @apply flex items-center gap-2 no-underline;
+  @apply bg-transparent text-charcoal font-sans;
+  @apply border border-dashed border-[#bdbdbd] rounded-[1.25rem];
+  padding: 0.5rem 1rem;
+  min-height: 44px;
+}
+
+.agenda-continuation__marker {
+  @apply flex-shrink-0 text-[#8a8a8a];
+  font-size: 0.75rem;
+}
+
+.agenda-continuation__body {
+  @apply flex flex-col min-w-0;
+}
+
+.agenda-continuation__title {
+  @apply block font-bold;
+  font-size: 0.875rem;
+  line-height: 1.25;
+  opacity: 0.75;
+}
+
+.agenda-continuation__meta {
+  @apply block text-[#6b6b6b];
+  font-size: 0.75rem;
+  line-height: 1.3;
+}
+
+.agenda-continuation__label {
+  @apply italic;
+}
+
+/* Breaks: full width, dashed, no room label - the grid's colSpan is
+   meaningless in a single column. Already de-duplicated in the data. */
+.agenda-break {
+  @apply flex flex-col items-center justify-center text-center;
+  @apply bg-[#f5f5f5] text-charcoal font-sans;
+  @apply border border-dashed border-[#ccc] rounded-[1.25rem];
+  padding: 0.75rem 1rem;
+  min-height: 44px;
+}
+
+.agenda-break__title {
+  @apply block font-extrabold;
+  font-size: 0.9375rem;
+}
+
+.agenda-break__time {
+  @apply block;
+  font-size: 0.8125rem;
+  opacity: 0.85;
 }
 
 .side-nav .active-page {

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -950,8 +950,13 @@ ul.sub-menu {
   }
 }
 
+/* Only a grid that has an agenda to replace it gets hidden. sunday.astro
+   reuses .schedule-wrapper for its hand-built single-block schedule and has no
+   agenda, so hiding every .schedule-wrapper left that page with nothing at all
+   below 768px. The marker class is opt-in for exactly this reason: a page that
+   reuses the grid styles keeps working unless it opts into the swap. */
 @media (max-width: 767.98px) {
-  .schedule-wrapper {
+  .schedule-wrapper--has-agenda {
     display: none;
   }
 }

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -971,19 +971,16 @@ ul.sub-menu {
 /* Sticky time heading. On a 34-session day the most common failure is losing
    track of what time you're looking at; this is what prevents it. It replaces
    the grid's sticky left time column, meaningless without a horizontal axis. */
+/* Matches the desktop time column's type: font-sans, semibold, base size.
+   The rule above it and the gap between groups carry the wayfinding weight
+   instead of an outsized type scale. */
 .agenda-group__time {
   @apply sticky top-0 z-20 bg-stone;
-  @apply font-serif text-charcoal;
-  /* Out-ranks the session titles beneath it - it is the primary wayfinding
-     element on the page, and three or four stacked cards can otherwise let
-     the titles dominate through sheer mass. */
-  font-size: 1.75rem;
-  line-height: 1.1;
-  letter-spacing: -0.02em;
+  @apply font-sans font-semibold text-charcoal tracking-[0.01rem];
   padding-top: 0.5rem;
   padding-bottom: 0.5rem;
   margin-bottom: 0.75rem;
-  border-bottom: 2px solid #313131;
+  border-bottom: 1px solid #DBDBDB;
 }
 
 .agenda-group__entries {
@@ -998,6 +995,8 @@ ul.sub-menu {
   @apply relative flex flex-col;
 }
 
+/* Track header matches the desktop treatment: sentence case as authored, not
+   uppercased, at the same size and colour. */
 .agenda-track-header {
   @apply flex items-center gap-2;
   @apply font-sans font-semibold text-sm;
@@ -1006,12 +1005,12 @@ ul.sub-menu {
 
 .agenda-track-icon {
   @apply flex-shrink-0;
-  width: 14px;
-  height: 14px;
+  width: 17.935px;
+  height: 17.936px;
 }
 
 .agenda-track-name {
-  @apply font-semibold text-[#747474] text-xs uppercase tracking-[0.08em];
+  @apply font-semibold text-[#747474];
 }
 
 .agenda-track-name--link {
@@ -1022,9 +1021,11 @@ ul.sub-menu {
   @apply text-charcoal underline;
 }
 
+/* Card typography matches the desktop .schedule-event exactly: font-sans,
+   font-medium, text-xs, with the time and title extrabold. */
 .agenda-card {
   @apply relative flex items-start justify-between gap-2;
-  @apply bg-white text-charcoal font-sans no-underline;
+  @apply bg-white text-charcoal font-sans font-medium text-xs no-underline;
   @apply rounded-[1.25rem];
   padding: 0.875rem 1rem;
   /* WCAG 2.5.8 / iOS HIG minimum tap target. */
@@ -1035,29 +1036,30 @@ ul.sub-menu {
   @apply pointer-events-none;
 }
 
+/* Continuations keep the session's own background; only the meta line marks
+   them as already under way. */
+.agenda-card--continuation {
+  @apply items-center;
+}
+
 .agenda-card__body {
   @apply flex flex-col min-w-0;
-  gap: 0.125rem;
+}
+
+.agenda-card__time {
+  @apply block font-extrabold;
 }
 
 .agenda-card__title {
   @apply block font-extrabold;
-  font-size: 1rem;
-  line-height: 1.25;
 }
 
 .agenda-card__meta {
-  @apply block font-medium;
-  font-size: 0.8125rem;
-  line-height: 1.3;
-  opacity: 0.85;
+  @apply block;
 }
 
 .agenda-card__speakers {
   @apply block;
-  font-size: 0.8125rem;
-  line-height: 1.3;
-  opacity: 0.85;
 }
 
 /* Reserved space for the Phase 3 favourite star. Deliberately empty rather
@@ -1071,62 +1073,23 @@ ul.sub-menu {
   margin: -0.375rem -0.5rem 0 0;
 }
 
-/* Continuation card: a session already under way, repeated so it isn't
-   invisible from its start time onward. Visibly subordinate to a real card -
-   if it reads as an identical duplicate, the design has failed. */
-.agenda-continuation {
-  @apply flex items-center gap-2 no-underline;
-  @apply bg-transparent text-charcoal font-sans;
-  @apply border border-dashed border-[#bdbdbd] rounded-[1.25rem];
-  padding: 0.5rem 1rem;
-  min-height: 44px;
-}
-
-.agenda-continuation__marker {
-  @apply flex-shrink-0 text-[#8a8a8a];
-  font-size: 0.75rem;
-}
-
-.agenda-continuation__body {
-  @apply flex flex-col min-w-0;
-}
-
-.agenda-continuation__title {
-  @apply block font-bold;
-  font-size: 0.875rem;
-  line-height: 1.25;
-  opacity: 0.75;
-}
-
-.agenda-continuation__meta {
-  @apply block text-[#6b6b6b];
-  font-size: 0.75rem;
-  line-height: 1.3;
-}
-
-.agenda-continuation__label {
-  @apply italic;
-}
-
 /* Breaks: full width, dashed, no room label - the grid's colSpan is
-   meaningless in a single column. Already de-duplicated in the data. */
+   meaningless in a single column. Already de-duplicated in the data.
+   Typography matches the desktop .schedule-break. */
 .agenda-break {
   @apply flex flex-col items-center justify-center text-center;
-  @apply bg-[#f5f5f5] text-charcoal font-sans;
+  @apply bg-[#f5f5f5] text-charcoal font-sans text-xs;
   @apply border border-dashed border-[#ccc] rounded-[1.25rem];
   padding: 0.75rem 1rem;
   min-height: 44px;
 }
 
 .agenda-break__title {
-  @apply block font-extrabold;
-  font-size: 0.9375rem;
+  @apply block font-extrabold text-charcoal;
 }
 
 .agenda-break__time {
-  @apply block;
-  font-size: 0.8125rem;
-  opacity: 0.85;
+  @apply block text-charcoal;
 }
 
 .side-nav .active-page {

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -903,7 +903,14 @@ ul.sub-menu {
 }
 
 .schedule-event-note {
-  @apply shrink-0 font-semibold italic;
+  @apply shrink-0 font-normal italic;
+  @apply inline-flex items-center gap-1;
+}
+
+.schedule-event-note-icon {
+  @apply shrink-0;
+  width: 1em;
+  height: 1em;
 }
 
 /* Break styling */
@@ -1038,8 +1045,11 @@ ul.sub-menu {
 
 /* Card typography matches the desktop .schedule-event exactly: font-sans,
    font-medium, text-xs, with the time and title extrabold. */
+/* Two stacked rows rather than a text column beside a full-height star
+   column, so padding stays even on all four sides and the bottom row gets the
+   card's full width. */
 .agenda-card {
-  @apply relative flex items-start justify-between gap-2;
+  @apply relative flex flex-col;
   @apply bg-white text-charcoal font-sans font-medium text-xs no-underline;
   @apply rounded-[1.25rem];
   padding: 0.875rem 1rem;
@@ -1051,15 +1061,24 @@ ul.sub-menu {
   @apply pointer-events-none;
 }
 
-/* Continuations keep the session's own background; only the meta line marks
-   them as already under way. */
-.agenda-card--continuation {
+/* Continuations are a single row with no star slot. */
+.agenda-card--continuation .agenda-card__row {
   @apply items-center;
 }
 
-/* Takes the width left over by the star slot, so the footer row's note can
-   sit against the card's right edge. */
-.agenda-card__body {
+/* A row: text on the left, the star slot or the note on the right. */
+.agenda-card__row {
+  @apply flex items-start justify-between gap-2 w-full;
+}
+
+/* The note sits against the card's bottom-right corner rather than aligning
+   to the first line of the room/speaker stack beside it. */
+.agenda-card__row--secondary {
+  @apply items-end;
+}
+
+.agenda-card__primary,
+.agenda-card__secondary {
   @apply flex flex-col min-w-0 flex-1;
 }
 
@@ -1079,27 +1098,30 @@ ul.sub-menu {
   @apply block;
 }
 
-/* Bottom row of the card: speaker on the left, any note pushed to the right.
-   Wraps rather than crushing the speaker name on a narrow phone. */
-.agenda-card__footer {
-  @apply flex flex-wrap items-baseline justify-between gap-x-2 w-full;
+/* Sits in the card's bottom-right corner - the star slot is in the row above,
+   so nothing indents this. */
+.agenda-card__note {
+  @apply shrink-0 font-normal italic text-right;
+  @apply inline-flex items-center gap-1;
 }
 
-/* ml-auto keeps the note against the right edge even when it wraps onto its
-   own line, where justify-between alone would leave it left-aligned. */
-.agenda-card__note {
-  @apply shrink-0 font-semibold italic ml-auto text-right;
+.agenda-card__note-icon {
+  @apply shrink-0;
+  width: 1em;
+  height: 1em;
 }
 
 /* Reserved space for the Phase 3 favourite star. Deliberately empty rather
-   than a visible-but-dead star, which invites tapping and disappoints. The
-   text column is sized around it so dropping a star in causes zero reflow. */
+   than a visible-but-dead star, which invites tapping and disappoints.
+   Beside the top row only, so it reserves width for the time and title
+   without pushing the bottom row in. Negative margins pull it level with the
+   time's cap height and out to the card's padding edge, where a 44px tap
+   target belongs; dropping a star in causes zero reflow. */
 .agenda-card__star-slot {
   @apply flex-shrink-0;
   width: 44px;
   height: 44px;
-  /* Pull level with the title's cap height rather than the card padding. */
-  margin: -0.375rem -0.5rem 0 0;
+  margin: -0.375rem -0.5rem -0.5rem 0;
 }
 
 /* Breaks: full width, dashed, no room label - the grid's colSpan is

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -896,6 +896,16 @@ ul.sub-menu {
   @apply block;
 }
 
+/* Bottom row of the card: speaker on the left, any note on the right. Wraps
+   rather than crushing the speaker name when the column is narrow. */
+.schedule-event-footer {
+  @apply flex flex-wrap items-baseline justify-between gap-x-2 w-full;
+}
+
+.schedule-event-note {
+  @apply shrink-0 font-semibold italic;
+}
+
 /* Break styling */
 .schedule-break-wrapper {
   z-index: 15;
@@ -1065,6 +1075,10 @@ ul.sub-menu {
 
 .agenda-card__speakers {
   @apply block;
+}
+
+.agenda-card__note {
+  @apply block font-semibold italic;
 }
 
 /* Reserved space for the Phase 3 favourite star. Deliberately empty rather

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1057,8 +1057,10 @@ ul.sub-menu {
   @apply items-center;
 }
 
+/* Takes the width left over by the star slot, so the footer row's note can
+   sit against the card's right edge. */
 .agenda-card__body {
-  @apply flex flex-col min-w-0;
+  @apply flex flex-col min-w-0 flex-1;
 }
 
 .agenda-card__time {
@@ -1077,8 +1079,16 @@ ul.sub-menu {
   @apply block;
 }
 
+/* Bottom row of the card: speaker on the left, any note pushed to the right.
+   Wraps rather than crushing the speaker name on a narrow phone. */
+.agenda-card__footer {
+  @apply flex flex-wrap items-baseline justify-between gap-x-2 w-full;
+}
+
+/* ml-auto keeps the note against the right edge even when it wraps onto its
+   own line, where justify-between alone would leave it left-aligned. */
 .agenda-card__note {
-  @apply block font-semibold italic;
+  @apply shrink-0 font-semibold italic ml-auto text-right;
 }
 
 /* Reserved space for the Phase 3 favourite star. Deliberately empty rather

--- a/src/utils/schedule.ts
+++ b/src/utils/schedule.ts
@@ -914,3 +914,178 @@ export async function getScheduleForGrid(
 
   return { rooms: filteredRooms, rows, layout: scheduleLayout };
 }
+
+// ============================================================================
+// Agenda layout (mobile, < 768px)
+// ============================================================================
+
+/**
+ * One appearance of a session within an agenda time group.
+ *
+ * A session that runs across more than one time group appears once per group;
+ * `isContinuation` is a property of that appearance, not of the session. Only
+ * the first appearance is a full card.
+ */
+export interface AgendaEntry {
+  session: Session;
+  isContinuation: boolean;
+  isBreak: boolean;
+  isFullWidth: boolean; // Plenary - spans all rooms, so carries no room label
+  showTrackHeader: boolean;
+  spansMultipleGroups: boolean; // Show a time range rather than a duration
+  durationMinutes: number;
+}
+
+/**
+ * A group of sessions sharing a start time in the agenda list.
+ * Boundaries are the day's distinct session start times, not fixed slots.
+ */
+export interface AgendaGroup {
+  time: Date;
+  label: string;
+  entries: AgendaEntry[];
+}
+
+/**
+ * Format a time for an agenda heading, e.g. "2:00pm".
+ */
+export function formatAgendaTime(date: Date): string {
+  return date
+    .toLocaleTimeString("en-AU", {
+      hour: "numeric",
+      minute: "2-digit",
+      hour12: true,
+      timeZone: CONFERENCE_TIMEZONE,
+    })
+    .replace(/\s(am|pm)/i, "$1")
+    .toLowerCase();
+}
+
+/**
+ * Get schedule data organized as a chronological agenda list, for the mobile
+ * layout below 768px. Sibling to `getScheduleForGrid` - both read the same
+ * session data, so the two layouts cannot disagree about what is on.
+ *
+ * Deliberately carries no grid geometry (topPercent, heightPx, colSpan,
+ * followsLongSession); those are artifacts of the grid's fixed rows.
+ */
+export async function getScheduleForAgenda(
+  dayName: string
+): Promise<AgendaGroup[]> {
+  const sessions = await getSessionsByDay(dayName);
+  const rooms = await getRoomsForDay(dayName);
+  const specialistTrackNames = await getSpecialistTrackNames();
+
+  const usable = sessions.filter(
+    (s) => s.data.start && s.data.end && s.data.room
+  );
+  if (usable.length === 0) return [];
+
+  // De-duplicate breaks on the same (start, end, title) key the grid's
+  // mergeAdjacentBreaks() uses, so Saturday's four-room Lunch collapses to a
+  // single full-width card. colSpan is meaningless in a single column, so
+  // contiguity doesn't matter here - any room set merges to one entry.
+  const breakKey = (s: Session) =>
+    `${s.data.start!.getTime()}-${s.data.end!.getTime()}-${s.data.title}`;
+  const seenBreaks = new Set<string>();
+  const deduped = usable.filter((s) => {
+    if (s.data.type !== "break") return true;
+    const key = breakKey(s);
+    if (seenBreaks.has(key)) return false;
+    seenBreaks.add(key);
+    return true;
+  });
+
+  // Track headers: shown only on the first session of a run in a room, matching
+  // the grid. Breaks don't count as a preceding session.
+  const nonBreakEndTimesByRoom = new Map<string, Set<number>>();
+  for (const s of deduped) {
+    if (s.data.type === "break") continue;
+    const room = s.data.room!;
+    if (!nonBreakEndTimesByRoom.has(room)) {
+      nonBreakEndTimesByRoom.set(room, new Set());
+    }
+    nonBreakEndTimesByRoom.get(room)!.add(s.data.end!.getTime());
+  }
+
+  // Group boundaries are the distinct start times of the day's sessions - the
+  // real times sessions begin, not clock-aligned buckets. Saturday's afternoon
+  // groups are therefore 14:00, 14:35 and 15:10.
+  const groupTimes = Array.from(
+    new Set(deduped.map((s) => s.data.start!.getTime()))
+  ).sort((a, b) => a - b);
+
+  // Stable room order within a group, matching the grid's column order.
+  const roomIndex = (room: string) => {
+    const i = rooms.indexOf(room);
+    return i === -1 ? rooms.length : i;
+  };
+
+  // A session belongs to every group whose start time falls within its run.
+  // Derived from start/end times, never from a session code or a duration
+  // threshold - the schedule regenerates from Pretalx and any long session
+  // added later must take this path too.
+  const groupsForSession = (s: Session): number[] => {
+    const start = s.data.start!.getTime();
+    const end = s.data.end!.getTime();
+    // Breaks are excluded from the repeat rule: a break spanning a group
+    // boundary is context, not something you can still join.
+    if (s.data.type === "break") return [start];
+    return groupTimes.filter((t) => t >= start && t < end);
+  };
+
+  const groups: AgendaGroup[] = groupTimes.map((time) => ({
+    time: new Date(time),
+    label: formatAgendaTime(new Date(time)),
+    entries: [],
+  }));
+  const groupByTime = new Map(groups.map((g) => [g.time.getTime(), g]));
+
+  for (const session of deduped) {
+    const start = session.data.start!.getTime();
+    const end = session.data.end!.getTime();
+    const isBreak = session.data.type === "break";
+    const isFullWidth = session.data.type === "plenary";
+    const room = session.data.room!;
+    const durationMinutes = Math.round((end - start) / (1000 * 60));
+
+    const memberGroups = groupsForSession(session);
+    const spansMultipleGroups = memberGroups.length > 1;
+
+    const trackName = session.data.trackName;
+    const isSpecialistTrack = !!trackName && specialistTrackNames.has(trackName);
+    const hasPrecedingSession =
+      !isBreak && (nonBreakEndTimesByRoom.get(room)?.has(start) ?? false);
+    const showTrackHeader = isSpecialistTrack && !hasPrecedingSession;
+
+    for (const groupTime of memberGroups) {
+      const group = groupByTime.get(groupTime);
+      if (!group) continue;
+      const isContinuation = groupTime !== start;
+      group.entries.push({
+        session,
+        isContinuation,
+        isBreak,
+        isFullWidth,
+        // Continuation cards never repeat the track header.
+        showTrackHeader: showTrackHeader && !isContinuation,
+        spansMultipleGroups,
+        durationMinutes,
+      });
+    }
+  }
+
+  // Within a group: regular sessions in room order first, then breaks, then
+  // continuation cards last - context for a block already under way.
+  for (const group of groups) {
+    group.entries.sort((a, b) => {
+      const rank = (e: AgendaEntry) =>
+        e.isContinuation ? 2 : e.isBreak ? 1 : 0;
+      if (rank(a) !== rank(b)) return rank(a) - rank(b);
+      if (a.isFullWidth !== b.isFullWidth) return a.isFullWidth ? -1 : 1;
+      return roomIndex(a.session.data.room!) - roomIndex(b.session.data.room!);
+    });
+  }
+
+  return groups.filter((g) => g.entries.length > 0);
+}

--- a/src/utils/schedule.ts
+++ b/src/utils/schedule.ts
@@ -1011,9 +1011,43 @@ export async function getScheduleForAgenda(
   // Group boundaries are the distinct start times of the day's sessions - the
   // real times sessions begin, not clock-aligned buckets. Saturday's afternoon
   // groups are therefore 14:00, 14:35 and 15:10.
-  const groupTimes = Array.from(
+  const allStartTimes = Array.from(
     new Set(deduped.map((s) => s.data.start!.getTime()))
   ).sort((a, b) => a - b);
+
+  // Sessions that run straight on from the one before them, in the same room,
+  // with no break between, read as one continuous block rather than as a new
+  // thing starting - the opening followed by the keynote, or the lightning
+  // talks followed by the closing address. The desktop grid gets this for free
+  // from geometry, because 9:15 simply isn't a slot boundary there. Here the
+  // start time would otherwise open its own group and put a time heading
+  // between two cards that belong together.
+  //
+  // Such a start time is absorbed into the previous group instead of beginning
+  // a new one. Derived from the times themselves, so it needs no flag in the
+  // source data and survives the schedule regenerating from Pretalx.
+  const isBackToBackStart = (time: number): boolean => {
+    const startingHere = deduped.filter(
+      (s) => s.data.start!.getTime() === time && s.data.type !== "break"
+    );
+    // Every session starting at this time must continue a session in its own
+    // room; if anything genuinely new begins here, the group stands on its own.
+    if (startingHere.length === 0) return false;
+    return startingHere.every((s) =>
+      deduped.some(
+        (prev) =>
+          prev !== s &&
+          prev.data.type !== "break" &&
+          prev.data.room === s.data.room &&
+          prev.data.end!.getTime() === time
+      )
+    );
+  };
+
+  // The first start time of the day always opens a group.
+  const groupTimes = allStartTimes.filter(
+    (t, i) => i === 0 || !isBackToBackStart(t)
+  );
 
   // Stable room order within a group, matching the grid's column order.
   const roomIndex = (room: string) => {
@@ -1021,17 +1055,32 @@ export async function getScheduleForAgenda(
     return i === -1 ? rooms.length : i;
   };
 
-  // A session belongs to every group whose start time falls within its run.
-  // Derived from start/end times, never from a session code or a duration
-  // threshold - the schedule regenerates from Pretalx and any long session
-  // added later must take this path too.
+  // The group a given start time is rendered under. Usually itself, but a
+  // back-to-back start was absorbed above, so it resolves to the latest group
+  // at or before it.
+  const owningGroup = (time: number): number => {
+    let owner = groupTimes[0];
+    for (const t of groupTimes) {
+      if (t <= time) owner = t;
+      else break;
+    }
+    return owner;
+  };
+
+  // A session belongs to every group whose start time falls within its run,
+  // plus the group that owns its own start time. Derived from start/end times,
+  // never from a session code or a duration threshold - the schedule
+  // regenerates from Pretalx and any long session added later must take this
+  // path too.
   const groupsForSession = (s: Session): number[] => {
     const start = s.data.start!.getTime();
     const end = s.data.end!.getTime();
     // Breaks are excluded from the repeat rule: a break spanning a group
     // boundary is context, not something you can still join.
-    if (s.data.type === "break") return [start];
-    return groupTimes.filter((t) => t >= start && t < end);
+    if (s.data.type === "break") return [owningGroup(start)];
+    const overlapping = groupTimes.filter((t) => t >= start && t < end);
+    const own = owningGroup(start);
+    return overlapping.includes(own) ? overlapping : [own, ...overlapping];
   };
 
   const groups: AgendaGroup[] = groupTimes.map((time) => ({
@@ -1050,7 +1099,9 @@ export async function getScheduleForAgenda(
     const durationMinutes = Math.round((end - start) / (1000 * 60));
 
     const memberGroups = groupsForSession(session);
-    const spansMultipleGroups = memberGroups.length > 1;
+    // Only a session appearing in a group later than its own counts as
+    // spanning; being absorbed into an earlier group doesn't make it long.
+    const spansMultipleGroups = memberGroups.some((t) => t > start);
 
     const trackName = session.data.trackName;
     const isSpecialistTrack = !!trackName && specialistTrackNames.has(trackName);
@@ -1061,7 +1112,10 @@ export async function getScheduleForAgenda(
     for (const groupTime of memberGroups) {
       const group = groupByTime.get(groupTime);
       if (!group) continue;
-      const isContinuation = groupTime !== start;
+      // A continuation is an appearance in a group that began after the
+      // session did. A session absorbed into an earlier group (back-to-back)
+      // starts after its group's time and is emphatically not a continuation.
+      const isContinuation = groupTime > start;
       group.entries.push({
         session,
         isContinuation,


### PR DESCRIPTION
Phase 1 of the mobile schedule work — [the plan](.claude/plans/phase-1-mobile-schedule.md), under [the parent scope doc](.claude/plans/schedule-pwa.md) §6.

## The problem

The schedule day pages weren't responsive. They rendered a fixed-width desktop grid and scrolled it sideways: 1040px on Thursday and Friday, **1360px on Saturday**, against a 390px phone — three and a half screens wide, with an 80px sticky time column eating into every drag.

A time grid's premise is spatial comparison across rooms, which needs horizontal room a phone doesn't have. So this adds a **second layout over the same data** rather than restyling the first.

## What's here

**Below 768px, a single chronological agenda list replaces the grid.** Both layouts render into the same document and CSS chooses between them — the site is pre-rendered, so a JS branch would flash the wrong layout on load.

`getScheduleForAgenda()` sits beside `getScheduleForGrid()` in `src/utils/schedule.ts` and carries none of the grid's geometry. Its time groups are the day's distinct session *start times*, not the grid's slot bucketing, so Saturday's afternoon groups are the real 14:00, 14:35 and 15:10.

**Sessions spanning multiple groups repeat as continuation cards.** Without this, an attendee scrolling at 14:35 sees three ballroom talks and no sign of the DevRel Unconference — the drop-in session most likely to be joined partway through. Membership is derived from start/end times, never a session code or duration threshold, since the schedule regenerates from Pretalx. It already catches Friday's Student Showcase as well as Saturday's unconference.

**Back-to-back sessions share a time heading.** The opening followed by its keynote, and Saturday's lightning talks followed by the closing address, read as one block — as they already do on desktop, where 9:15 simply isn't a slot boundary. Derived from the times themselves, so no flag in the source data and nothing to maintain by hand.

**The tablet grid is repaired** (768–1023px). It previously held its fixed canvas until 1024px, so a tablet scrolled sideways exactly like a phone. Columns now divide available width: ~212px on Thursday/Friday, ~156px on Saturday. The `--span-*` calculations now derive from a `--schedule-gutter` variable rather than repeating a `1.5rem` literal, so a gutter change can't silently misalign spanning plenaries and breaks.

**Also in scope:** a reserved 44px favourite-star slot (inert until Phase 3, sized so dropping a star in causes no reflow), per-session page tightening, the conference day in the session breadcrumb, and a "Separate registration" note on workshop cards.

### Two pre-existing bugs fixed along the way

- The track header slot is a fixed 24px, so "Research Software Engineering" wrapped and had its second line clipped behind the card below it, below ~1290px where the 4-room Saturday columns get narrower than the label. It now steps down a size and can't wrap.
- The "Workshops" track name in the session header now links to `/schedule/workshops`, matching how specialist tracks link to their own pages.

## Verification

Measured in a real browser at 320/390/430/768/900/1024/1280px across all five day pages:

- **No horizontal overflow anywhere** — the headline criterion
- Exactly one column of cards below 768px; no two ever side by side
- Every card at least 44px
- Desktop (≥1024px) visually unchanged
- The DevRel Unconference appears in all three of Saturday's 14:00, 14:35 and 15:10 groups — full card first, continuations after, star slot on the first only
- All 104 published session pages carry a day breadcrumb; all 39 track/workshop links resolve 200

`astro check`: 0 errors, 0 warnings.

## Not in this PR

`/schedule/today` (§7 item 8) — independent of the above and deliberately left for a follow-up.

`sunday.astro` overflows slightly at 320px (its 297px block plus the time gutter). It's pre-existing, out of scope per the plan, and reported rather than fixed — worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
