### PR TITLE
Phase 3a: local favourites on the schedule

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,16 @@
+Third-party assets bundled in this repository.
+
+Material Symbols
+https://github.com/google/material-design-icons
+Copyright Google LLC
+Licensed under the Apache License, Version 2.0
+https://www.apache.org/licenses/LICENSE-2.0
+
+Individual Material Symbols glyphs are inlined as SVG paths rather than loaded
+as an icon font, so that they cost no extra request and inherit the surrounding
+element's colour. The glyphs used are:
+
+  info                                     src/components/schedule/AgendaList.astro
+                                           src/pages/schedule/[day].astro
+  bookmark, bookmark_border,
+  bookmark_add, bookmark_added             src/components/schedule/BookmarkButton.astro

--- a/NOTICE
+++ b/NOTICE
@@ -13,4 +13,5 @@ element's colour. The glyphs used are:
   info                                     src/components/schedule/AgendaList.astro
                                            src/pages/schedule/[day].astro
   bookmark, bookmark_border,
-  bookmark_add, bookmark_added             src/components/schedule/BookmarkButton.astro
+  bookmark_add, bookmark_added,
+  bookmark_heart                           src/components/schedule/BookmarkButton.astro

--- a/src/components/schedule/AgendaList.astro
+++ b/src/components/schedule/AgendaList.astro
@@ -5,6 +5,7 @@ import {
   formatAgendaTime,
   getTrackColor,
 } from "../../utils/schedule";
+import BookmarkButton from "./BookmarkButton.astro";
 
 interface Props {
   groups: AgendaGroup[];
@@ -129,8 +130,8 @@ const { groups, speakerMap, trackSlugs } = Astro.props;
                   style={`background-color: ${trackColor.bg}; color: ${trackColor.text};`}
                 >
                   {/* Two rows, each a flex pair. Top: time + title, with the
-                      star beside them. Bottom: room + speakers, with any
-                      registration note on the right. The star sits only
+                      bookmark beside them. Bottom: room + speakers, with any
+                      registration note on the right. The bookmark sits only
                       against the top row rather than spanning the card's full
                       height, so the bottom row keeps the card's full width. */}
                   <div class="agenda-card__row">
@@ -139,10 +140,15 @@ const { groups, speakerMap, trackSlugs } = Astro.props;
                       <span class="agenda-card__title">{title}</span>
                     </div>
 
-                    {/* Reserved for the Phase 3 favourite star. Renders as
-                        empty space, not a dead control - dropping a 44px star
-                        in here must cause no reflow. */}
-                    <div class="agenda-card__star-slot" aria-hidden="true"></div>
+                    {/* The favourite bookmark, filling the 44px slot Phase 1
+                        reserved for it. Inside the card, so it inherits the
+                        track's text colour via currentColor. A session with no
+                        page of its own has no code to favourite against. */}
+                    <div class="agenda-card__star-slot">
+                      {!isNotYetAnnounced && (
+                        <BookmarkButton code={code} title={title} />
+                      )}
+                    </div>
                   </div>
 
                   <div class="agenda-card__row agenda-card__row--secondary">

--- a/src/components/schedule/BookmarkButton.astro
+++ b/src/components/schedule/BookmarkButton.astro
@@ -1,0 +1,85 @@
+---
+// The favourite control — Phase 3a (.claude/plans/phase-3a-local-favourites.md §3).
+//
+// A bookmark, not a star: it reads as "save this for later", and it keeps clear
+// of the star motif used decoratively across the site.
+//
+// All four Material Symbols glyphs (Apache 2.0 — see NOTICE) ship inline in the
+// markup and CSS picks between them. Four paths is the wrong size for an icon
+// font: that would be a render-blocking request showing tofu until it lands,
+// exactly when conference wifi is worst. Inlining also matches how the grid
+// already draws its track markers.
+//
+// Every icon uses fill="currentColor" and nothing here takes a colour. The
+// cards set `color: ${trackColor.text}` on themselves, so the glyph inherits a
+// colour already chosen to read against that track's background — on every
+// track, including any added later. Passing a colour in would duplicate a
+// decision that already lives in trackColors.
+
+interface Props {
+  /** Session code — the identity the favourite is stored against. */
+  code: string;
+  /** Session title, for the accessible name. */
+  title: string;
+  /**
+   * Where the button sits. "card" hover-reveals on pointer devices and is
+   * always visible on touch; "detail" is always visible (§3.3).
+   */
+  variant?: "card" | "detail";
+  class?: string;
+}
+
+const { code, title, variant = "card", class: className = "" } = Astro.props;
+---
+
+{/*
+  A real <button>, so it is focusable and activatable by keyboard for free.
+  aria-pressed carries the toggle state and aria-label names the session — a
+  page of buttons all labelled "Save" is unusable on a screen reader. The glyph
+  itself is decorative, so the transient bookmark_added swap never produces a
+  confusing mid-interaction announcement.
+
+  type="button" matters: inside a form this would otherwise submit.
+
+  data-session-code is the client's handle on the session (§7). The code is
+  otherwise only in the card's href, and parsing it back out of a URL would
+  couple favourites to the routing scheme.
+*/}
+<button
+  type="button"
+  class={`bookmark-btn bookmark-btn--${variant}${className ? ` ${className}` : ""}`}
+  data-session-code={code}
+  data-session-title={title}
+  aria-pressed="false"
+  aria-label={`Save: ${title}`}
+>
+  <svg
+    class="bookmark-btn__icon"
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 -960 960 960"
+    fill="currentColor"
+    aria-hidden="true"
+    focusable="false"
+  >
+    {/* bookmark_border — unfavourited */}
+    <path
+      class="bookmark-btn__glyph bookmark-btn__glyph--border"
+      d="M200-120v-640q0-33 23.5-56.5T280-840h400q33 0 56.5 23.5T760-760v640L480-240 200-120Zm80-122 200-86 200 86v-518H280v518Zm0-518h400-400Z"
+    />
+    {/* bookmark_add — hover or focus intent, unfavourited */}
+    <path
+      class="bookmark-btn__glyph bookmark-btn__glyph--add"
+      d="M200-120v-640q0-33 23.5-56.5T280-840h240v80H280v518l200-86 200 86v-278h80v400L480-240 200-120Zm80-640h240-240Zm400 160v-80h-80v-80h80v-80h80v80h80v80h-80v80h-80Z"
+    />
+    {/* bookmark_added — transient confirmation after favouriting */}
+    <path
+      class="bookmark-btn__glyph bookmark-btn__glyph--added"
+      d="m200-120 280-120 280 120v-640q0-33-23.5-56.5T680-840H280q-33 0-56.5 23.5T200-760v640Zm240-320L280-600l56-56 104 104 224-224 56 56-280 280Z"
+    />
+    {/* bookmark — favourited */}
+    <path
+      class="bookmark-btn__glyph bookmark-btn__glyph--filled"
+      d="M200-120v-640q0-33 23.5-56.5T280-840h400q33 0 56.5 23.5T760-760v640L480-240 200-120Z"
+    />
+  </svg>
+</button>

--- a/src/components/schedule/BookmarkButton.astro
+++ b/src/components/schedule/BookmarkButton.astro
@@ -44,49 +44,42 @@ const disabled = !pinned && isNotFavouritable(code);
 
 // A pinned bookmark has nothing to activate, so it is not a button.
 const Element = pinned ? "span" : "button";
+
+// Sessions that cannot be favourited render nothing at all. A greyed-out
+// control still reads as a control - it draws the eye, invites a tap and then
+// refuses - and Wednesday is workshops end to end, so that meant a column of
+// dead icons. The card already carries a "Separate registration" note, which
+// says the same thing without implying an action.
+//
+// Ordinarily this is a real <button>, so it is focusable and activatable by
+// keyboard for free. aria-pressed carries the toggle state and aria-label
+// names the session - a page of buttons all labelled "Save" is unusable on a
+// screen reader. The glyph is decorative, so the transient bookmark_added swap
+// never produces a confusing mid-interaction announcement. type="button"
+// matters: inside a form this would otherwise submit.
+//
+// data-session-code is the client's handle on the session (plan §7). The code
+// is otherwise only in the card's href, and parsing it back out of a URL would
+// couple favourites to the routing scheme.
+//
+// A pinned session renders a <span role="img"> instead: there is no action to
+// offer, so it should not be focusable or announced as a control. It is still
+// announced - as an image with a name - because "everyone is at this one" is
+// information a screen reader user needs just as much; aria-hidden would have
+// hidden it from them entirely while leaving it visible to everyone else.
 ---
 
-{/*
-  Ordinarily a real <button>, so it is focusable and activatable by keyboard
-  for free. aria-pressed carries the toggle state and aria-label names the
-  session — a page of buttons all labelled "Save" is unusable on a screen
-  reader. The glyph itself is decorative, so the transient bookmark_added swap
-  never produces a confusing mid-interaction announcement.
-
-  type="button" matters: inside a form this would otherwise submit.
-
-  data-session-code is the client's handle on the session (§7). The code is
-  otherwise only in the card's href, and parsing it back out of a URL would
-  couple favourites to the routing scheme.
-
-  A pinned session renders a <span role="img"> rather than a disabled <button>:
-  there is no action to offer, so it should not be focusable or announced as a
-  control. It is still announced — as an image with a name — because "everyone
-  is at this one" is information a screen reader user needs just as much;
-  aria-hidden would have hidden it from them entirely while leaving it visible
-  to everyone else.
-
-  Disabled sessions do stay buttons — the control is real but switched off,
-  which is what `disabled` means, and it is the element the eventual
-  registration-aware treatment will replace.
-*/}
+{!disabled && (
 <Element
   type={pinned ? undefined : "button"}
-  class={`bookmark-btn bookmark-btn--${variant}${pinned ? " bookmark-btn--pinned" : ""}${disabled ? " bookmark-btn--disabled" : ""}${className ? ` ${className}` : ""}`}
+  class={`bookmark-btn bookmark-btn--${variant}${pinned ? " bookmark-btn--pinned" : ""}${className ? ` ${className}` : ""}`}
   data-session-code={code}
   data-session-title={title}
   data-pinned={pinned ? "true" : undefined}
-  disabled={disabled ? true : undefined}
-  aria-pressed={pinned || disabled ? undefined : "false"}
+  aria-pressed={pinned ? undefined : "false"}
   role={pinned ? "img" : undefined}
   title={pinned ? "Everyone's invited to this one" : undefined}
-  aria-label={
-    pinned
-      ? `Everyone's invited: ${title}`
-      : disabled
-        ? `Separate registration required: ${title}`
-        : `Save: ${title}`
-  }
+  aria-label={pinned ? `Everyone's invited: ${title}` : `Save: ${title}`}
 >
   <svg
     class="bookmark-btn__icon"
@@ -116,5 +109,13 @@ const Element = pinned ? "span" : "button";
       class="bookmark-btn__glyph bookmark-btn__glyph--filled"
       d="M200-120v-640q0-33 23.5-56.5T280-840h400q33 0 56.5 23.5T760-760v640L480-240 200-120Z"
     />
+    {/* bookmark_heart — pinned: everyone is at this one. A distinct glyph
+        rather than the plain filled bookmark, so "we've saved this for you"
+        does not look identical to "you saved this". */}
+    <path
+      class="bookmark-btn__glyph bookmark-btn__glyph--heart"
+      d="M480-388q51-47 82.5-77.5T611-518q17-22 23-38.5t6-35.5q0-36-26-62t-62-26q-21 0-40.5 8.5T480-648q-12-15-31-23.5t-41-8.5q-36 0-62 26t-26 62q0 19 5.5 35t22.5 38q17 22 48 52.5t84 78.5ZM200-120v-640q0-33 23.5-56.5T280-840h400q33 0 56.5 23.5T760-760v640L480-240 200-120Z"
+    />
   </svg>
 </Element>
+)}

--- a/src/components/schedule/BookmarkButton.astro
+++ b/src/components/schedule/BookmarkButton.astro
@@ -16,6 +16,11 @@
 // track, including any added later. Passing a colour in would duplicate a
 // decision that already lives in trackColors.
 
+import {
+  isAlwaysFavourited,
+  isNotFavouritable,
+} from "../../utils/favourites-config";
+
 interface Props {
   /** Session code — the identity the favourite is stored against. */
   code: string;
@@ -30,28 +35,58 @@ interface Props {
 }
 
 const { code, title, variant = "card", class: className = "" } = Astro.props;
+
+// Two curated exceptions to ordinary favouriting, both keyed on session code.
+// Pinned wins if a code somehow appears in both lists: "everyone is at this"
+// is a stronger statement than "you cannot save this".
+const pinned = isAlwaysFavourited(code);
+const disabled = !pinned && isNotFavouritable(code);
+
+// A pinned bookmark has nothing to activate, so it is not a button.
+const Element = pinned ? "span" : "button";
 ---
 
 {/*
-  A real <button>, so it is focusable and activatable by keyboard for free.
-  aria-pressed carries the toggle state and aria-label names the session — a
-  page of buttons all labelled "Save" is unusable on a screen reader. The glyph
-  itself is decorative, so the transient bookmark_added swap never produces a
-  confusing mid-interaction announcement.
+  Ordinarily a real <button>, so it is focusable and activatable by keyboard
+  for free. aria-pressed carries the toggle state and aria-label names the
+  session — a page of buttons all labelled "Save" is unusable on a screen
+  reader. The glyph itself is decorative, so the transient bookmark_added swap
+  never produces a confusing mid-interaction announcement.
 
   type="button" matters: inside a form this would otherwise submit.
 
   data-session-code is the client's handle on the session (§7). The code is
   otherwise only in the card's href, and parsing it back out of a URL would
   couple favourites to the routing scheme.
+
+  A pinned session renders a <span role="img"> rather than a disabled <button>:
+  there is no action to offer, so it should not be focusable or announced as a
+  control. It is still announced — as an image with a name — because "everyone
+  is at this one" is information a screen reader user needs just as much;
+  aria-hidden would have hidden it from them entirely while leaving it visible
+  to everyone else.
+
+  Disabled sessions do stay buttons — the control is real but switched off,
+  which is what `disabled` means, and it is the element the eventual
+  registration-aware treatment will replace.
 */}
-<button
-  type="button"
-  class={`bookmark-btn bookmark-btn--${variant}${className ? ` ${className}` : ""}`}
+<Element
+  type={pinned ? undefined : "button"}
+  class={`bookmark-btn bookmark-btn--${variant}${pinned ? " bookmark-btn--pinned" : ""}${disabled ? " bookmark-btn--disabled" : ""}${className ? ` ${className}` : ""}`}
   data-session-code={code}
   data-session-title={title}
-  aria-pressed="false"
-  aria-label={`Save: ${title}`}
+  data-pinned={pinned ? "true" : undefined}
+  disabled={disabled ? true : undefined}
+  aria-pressed={pinned || disabled ? undefined : "false"}
+  role={pinned ? "img" : undefined}
+  title={pinned ? "Everyone's invited to this one" : undefined}
+  aria-label={
+    pinned
+      ? `Everyone's invited: ${title}`
+      : disabled
+        ? `Separate registration required: ${title}`
+        : `Save: ${title}`
+  }
 >
   <svg
     class="bookmark-btn__icon"
@@ -82,4 +117,4 @@ const { code, title, variant = "card", class: className = "" } = Astro.props;
       d="M200-120v-640q0-33 23.5-56.5T280-840h400q33 0 56.5 23.5T760-760v640L480-240 200-120Z"
     />
   </svg>
-</button>
+</Element>

--- a/src/pages/schedule/[code].astro
+++ b/src/pages/schedule/[code].astro
@@ -3,6 +3,7 @@ import { getCollection } from "astro:content";
 import Footer from "../../components/Footer.astro";
 import Header from "../../components/Header.astro";
 import Base from "../../layouts/Base.astro";
+import BookmarkButton from "../../components/schedule/BookmarkButton.astro";
 import SpeakerCard from "../../components/schedule/SpeakerCard.astro";
 import {
   getPeopleByCode,
@@ -147,6 +148,17 @@ const trackHref = trackData
             {title}
           </h1>
 
+          {/* The favourite bookmark. Always visible here - there is one control
+              and it isn't competing with a dense grid, so a hover reveal would
+              only hide it. This page carries no track colour, so currentColor
+              resolves to ordinary page text, which is the right answer.
+              Breaks aren't favouritable. */}
+          {type !== "break" && (
+            <div class="fadeInUp flex justify-center pt-3">
+              <BookmarkButton code={code} title={title} variant="detail" />
+            </div>
+          )}
+
           <div class="fadeInUp flex flex-wrap lg:flex-nowrap items-center justify-between border-t-2 border-emerald text-sm font-semibold text-emerald mt-7 pt-1 gap-2">
             {displayTrackName && (
               trackHref ? (
@@ -288,6 +300,7 @@ const trackHref = trackData
   <Footer />
 
   <script src="/src/scripts/animations.js"></script>
+  <script src="/src/scripts/favourites.js"></script>
   <script>
     const btn = document.getElementById("copy-link-btn");
     if (btn) {

--- a/src/pages/schedule/[day].astro
+++ b/src/pages/schedule/[day].astro
@@ -3,6 +3,7 @@ import { getCollection } from "astro:content";
 import Footer from "../../components/Footer.astro";
 import Header from "../../components/Header.astro";
 import AgendaList from "../../components/schedule/AgendaList.astro";
+import BookmarkButton from "../../components/schedule/BookmarkButton.astro";
 import DayTabs from "../../components/schedule/DayTabs.astro";
 import Base from "../../layouts/Base.astro";
 import {
@@ -150,6 +151,17 @@ const trackSlugs = new Set(
                               class="schedule-event"
                               style={`height: ${ps.heightPx}px; background-color: white; color: #282828;`}
                             >
+                              {/* Plenaries are favouritable; breaks are not,
+                                  and render as .schedule-break rather than
+                                  through here. Overlaid, not in the flow -
+                                  the card's height comes from the session's
+                                  duration and cannot grow. */}
+                              {!isNotYetAnnounced && (
+                                <BookmarkButton
+                                  code={ps.session.data.code}
+                                  title={ps.session.data.title}
+                                />
+                              )}
                               <div>
                                 <span class="schedule-event-time">{timeStr}</span>
                               </div>
@@ -269,6 +281,16 @@ const trackSlugs = new Set(
                               class="schedule-event"
                               style={`height: ${ps.heightPx}px; background-color: ${trackColor.bg}; color: ${trackColor.text};`}
                             >
+                              {/* Inside the card, so currentColor resolves to
+                                  this track's text colour. Overlaid rather
+                                  than in the flow, so the shortest cards
+                                  neither reflow nor clip their title. */}
+                              {!isNotYetAnnounced && (
+                                <BookmarkButton
+                                  code={ps.session.data.code}
+                                  title={ps.session.data.title}
+                                />
+                              )}
                               <div>
                                 <span class="schedule-event-time">{timeStr}</span>
                               </div>
@@ -345,4 +367,5 @@ const trackSlugs = new Set(
   <Footer />
 
   <script src="/src/scripts/animations.js"></script>
+  <script src="/src/scripts/favourites.js"></script>
 </Base>

--- a/src/pages/schedule/[day].astro
+++ b/src/pages/schedule/[day].astro
@@ -153,17 +153,15 @@ const trackSlugs = new Set(
                             >
                               {/* Plenaries are favouritable; breaks are not,
                                   and render as .schedule-break rather than
-                                  through here. Overlaid, not in the flow -
-                                  the card's height comes from the session's
-                                  duration and cannot grow. */}
-                              {!isNotYetAnnounced && (
-                                <BookmarkButton
-                                  code={ps.session.data.code}
-                                  title={ps.session.data.title}
-                                />
-                              )}
-                              <div>
+                                  through here. */}
+                              <div class="schedule-event-top">
                                 <span class="schedule-event-time">{timeStr}</span>
+                                {!isNotYetAnnounced && (
+                                  <BookmarkButton
+                                    code={ps.session.data.code}
+                                    title={ps.session.data.title}
+                                  />
+                                )}
                               </div>
                               <div>
                                 <span class="schedule-event-topic">{ps.session.data.title}</span>
@@ -281,18 +279,18 @@ const trackSlugs = new Set(
                               class="schedule-event"
                               style={`height: ${ps.heightPx}px; background-color: ${trackColor.bg}; color: ${trackColor.text};`}
                             >
-                              {/* Inside the card, so currentColor resolves to
-                                  this track's text colour. Overlaid rather
-                                  than in the flow, so the shortest cards
-                                  neither reflow nor clip their title. */}
-                              {!isNotYetAnnounced && (
-                                <BookmarkButton
-                                  code={ps.session.data.code}
-                                  title={ps.session.data.title}
-                                />
-                              )}
-                              <div>
+                              {/* Time and bookmark share the top row, the same
+                                  pairing the agenda card uses. Inside the
+                                  card, so currentColor resolves to this
+                                  track's text colour. */}
+                              <div class="schedule-event-top">
                                 <span class="schedule-event-time">{timeStr}</span>
+                                {!isNotYetAnnounced && (
+                                  <BookmarkButton
+                                    code={ps.session.data.code}
+                                    title={ps.session.data.title}
+                                  />
+                                )}
                               </div>
                               <div class="w-full">
                                 <span class="schedule-event-topic">{ps.session.data.title}</span>

--- a/src/scripts/favourites-storage.js
+++ b/src/scripts/favourites-storage.js
@@ -1,0 +1,156 @@
+// Local favourites storage — Phase 3a (.claude/plans/phase-3a-local-favourites.md §4).
+//
+// Session code -> ISO timestamp, in localStorage. Nothing else is stored: no
+// titles, times or rooms. A favourite is a reference into the schedule, not a
+// snapshot of it, so it can never go stale when the schedule flexes.
+//
+// No network, no sync, no auth. Phase 3b adds those on top of this shape.
+
+export const STORAGE_KEY = "pyconau2026.favourites";
+export const STORAGE_VERSION = 1;
+
+/**
+ * The empty document. `migratedToAccount` is reserved for Phase 3b's one-time
+ * anonymous -> authenticated merge (§6): the flag has to exist from the first
+ * version, or devices that already merged have no record of it and their
+ * deliberately-deleted favourites get resurrected.
+ */
+function emptyStore() {
+  return { version: STORAGE_VERSION, favourites: {}, migratedToAccount: false };
+}
+
+/**
+ * In-memory fallback for when localStorage is unavailable — Safari private
+ * browsing throws on access, and it can be disabled outright (§4.4).
+ * Favourites then work for the session and evaporate. Deliberately silent: an
+ * attendee who has locked their browser down doesn't need a warning.
+ */
+let memoryStore = null;
+
+let storageAvailable;
+
+function hasLocalStorage() {
+  if (storageAvailable !== undefined) return storageAvailable;
+  try {
+    const probe = "__pyconau_probe__";
+    window.localStorage.setItem(probe, probe);
+    window.localStorage.removeItem(probe);
+    storageAvailable = true;
+  } catch {
+    storageAvailable = false;
+  }
+  return storageAvailable;
+}
+
+/**
+ * Read the stored document, treating everything in localStorage as untrusted
+ * (§4.2). It is shared, user-editable and survives deploys, so anything
+ * unexpected — unparseable JSON, a future version, a hand-edited shape —
+ * resolves to empty rather than throwing on page load and taking the schedule
+ * down with it. The bad value is left in place and overwritten on next write.
+ */
+export function read() {
+  if (!hasLocalStorage()) {
+    if (!memoryStore) memoryStore = emptyStore();
+    return memoryStore;
+  }
+
+  let raw;
+  try {
+    raw = window.localStorage.getItem(STORAGE_KEY);
+  } catch {
+    return emptyStore();
+  }
+
+  if (!raw) return emptyStore();
+
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return emptyStore();
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return emptyStore();
+  }
+
+  // An unknown version is not interpreted — guessing at what an older or newer
+  // shape meant is how a migration goes wrong.
+  if (parsed.version !== STORAGE_VERSION) return emptyStore();
+
+  const source =
+    parsed.favourites &&
+    typeof parsed.favourites === "object" &&
+    !Array.isArray(parsed.favourites)
+      ? parsed.favourites
+      : {};
+
+  // Keep only code -> string pairs. A hand-edited object value or a null would
+  // otherwise flow through to the merge in Phase 3b.
+  const favourites = {};
+  for (const [code, addedAt] of Object.entries(source)) {
+    if (typeof code === "string" && code && typeof addedAt === "string") {
+      favourites[code] = addedAt;
+    }
+  }
+
+  return {
+    version: STORAGE_VERSION,
+    favourites,
+    migratedToAccount: parsed.migratedToAccount === true,
+  };
+}
+
+/**
+ * Write synchronously — no debounce. The data is tiny, and losing a write
+ * because someone closed the tab immediately is far worse than writing often
+ * (§3.5). A quota or private-browsing failure falls back to memory rather than
+ * throwing into a click handler.
+ */
+export function write(store) {
+  if (!hasLocalStorage()) {
+    memoryStore = store;
+    return;
+  }
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(store));
+  } catch {
+    memoryStore = store;
+  }
+}
+
+/** Is this session code favourited? */
+export function has(code) {
+  if (!code) return false;
+  return Object.prototype.hasOwnProperty.call(read().favourites, code);
+}
+
+/** Every favourited session code. Order is not meaningful. */
+export function list() {
+  return Object.keys(read().favourites);
+}
+
+export function add(code) {
+  if (!code) return false;
+  const store = read();
+  store.favourites[code] = new Date().toISOString();
+  write(store);
+  return true;
+}
+
+export function remove(code) {
+  if (!code) return false;
+  const store = read();
+  delete store.favourites[code];
+  write(store);
+  return false;
+}
+
+/**
+ * Toggle a favourite, returning the resulting state: true if it is now
+ * favourited, false if it is not.
+ */
+export function toggle(code) {
+  return has(code) ? remove(code) : add(code);
+}

--- a/src/scripts/favourites.js
+++ b/src/scripts/favourites.js
@@ -34,6 +34,11 @@ function clearTransient(button) {
  * here directly, never by way of the confirmation transient (§9).
  */
 function applyState(button, favourited) {
+  // A disabled bookmark is not a toggle: it carries neither aria-pressed nor a
+  // "Save:" label, since both would promise an action it does not offer. The
+  // server-rendered label already explains why it cannot be used.
+  if (button.disabled) return;
+
   button.setAttribute("aria-pressed", favourited ? "true" : "false");
 
   // The label follows the action the button will perform, not the state it is
@@ -82,6 +87,10 @@ function hydrate() {
   if (buttons.length === 0) return;
 
   for (const button of buttons) {
+    // Pinned bookmarks are rendered filled and inert by the server and carry
+    // no aria-pressed to correct. Leave them exactly as they came.
+    if (button.dataset.pinned === "true") continue;
+
     const code = button.dataset.sessionCode;
     // A stored code that isn't in this build's schedule — a cancelled session,
     // or a stale entry — simply has no button here. It is skipped, not
@@ -101,8 +110,17 @@ function init() {
     const button = event.target.closest?.(BUTTON_SELECTOR);
     if (!button) return;
 
+    // Always swallow the click, whatever the bookmark's state. A disabled
+    // <button> fires no click of its own, but the event still reaches the card
+    // link underneath it — so without this, tapping a workshop's switched-off
+    // bookmark would navigate to the session page, which is precisely the bug
+    // this guard exists to prevent everywhere else.
     event.preventDefault();
     event.stopPropagation();
+
+    // Pinned and disabled bookmarks are not toggles. The click is absorbed
+    // above and nothing further happens.
+    if (button.dataset.pinned === "true" || button.disabled) return;
 
     onToggle(button);
   });

--- a/src/scripts/favourites.js
+++ b/src/scripts/favourites.js
@@ -34,11 +34,6 @@ function clearTransient(button) {
  * here directly, never by way of the confirmation transient (§9).
  */
 function applyState(button, favourited) {
-  // A disabled bookmark is not a toggle: it carries neither aria-pressed nor a
-  // "Save:" label, since both would promise an action it does not offer. The
-  // server-rendered label already explains why it cannot be used.
-  if (button.disabled) return;
-
   button.setAttribute("aria-pressed", favourited ? "true" : "false");
 
   // The label follows the action the button will perform, not the state it is
@@ -110,17 +105,15 @@ function init() {
     const button = event.target.closest?.(BUTTON_SELECTOR);
     if (!button) return;
 
-    // Always swallow the click, whatever the bookmark's state. A disabled
-    // <button> fires no click of its own, but the event still reaches the card
-    // link underneath it — so without this, tapping a workshop's switched-off
-    // bookmark would navigate to the session page, which is precisely the bug
-    // this guard exists to prevent everywhere else.
+    // Always swallow the click, whatever the bookmark's state — including a
+    // pinned one, which is a <span> inside a card that is a link. Without this
+    // the event would reach that link and navigate to the session page.
     event.preventDefault();
     event.stopPropagation();
 
-    // Pinned and disabled bookmarks are not toggles. The click is absorbed
-    // above and nothing further happens.
-    if (button.dataset.pinned === "true" || button.disabled) return;
+    // A pinned bookmark is not a toggle. The click is absorbed above and
+    // nothing further happens.
+    if (button.dataset.pinned === "true") return;
 
     onToggle(button);
   });

--- a/src/scripts/favourites.js
+++ b/src/scripts/favourites.js
@@ -1,0 +1,123 @@
+// Favourite bookmarks — Phase 3a (.claude/plans/phase-3a-local-favourites.md).
+//
+// Dependency-free vanilla JS, matching the rest of src/scripts. One delegated
+// listener at the document level rather than one per card: a 37-session
+// Saturday means 37 buttons, and delegation is both cheaper and survives any
+// future re-render of the list.
+
+import { has, toggle } from "./favourites-storage.js";
+
+const BUTTON_SELECTOR = ".bookmark-btn";
+
+/** How long the bookmark_added confirmation shows before settling to filled. */
+const TRANSIENT_MS = 1200;
+
+/**
+ * Pending confirmation timers, keyed by the button they belong to. Tracked so a
+ * second tap inside the window can cancel one — the transient must never
+ * swallow or queue behind a tap — and so a timer can be cleared before it fires
+ * against an element that has gone away.
+ */
+const transientTimers = new WeakMap();
+
+function clearTransient(button) {
+  const timer = transientTimers.get(button);
+  if (timer !== undefined) {
+    window.clearTimeout(timer);
+    transientTimers.delete(button);
+  }
+  button.classList.remove("is-just-added");
+}
+
+/**
+ * Put a button into its settled state. Hydration and un-favouriting both land
+ * here directly, never by way of the confirmation transient (§9).
+ */
+function applyState(button, favourited) {
+  button.setAttribute("aria-pressed", favourited ? "true" : "false");
+
+  // The label follows the action the button will perform, not the state it is
+  // in — aria-pressed already carries the state.
+  const title = button.dataset.sessionTitle;
+  if (title) {
+    button.setAttribute(
+      "aria-label",
+      `${favourited ? "Remove from saved" : "Save"}: ${title}`
+    );
+  }
+}
+
+function onToggle(button) {
+  const code = button.dataset.sessionCode;
+  if (!code) return;
+
+  // A tap during the confirmation window is a real un-favourite, so cancel the
+  // pending settle first and let the toggle below decide the new state.
+  clearTransient(button);
+
+  const favourited = toggle(code);
+  applyState(button, favourited);
+
+  // Confirmation on add only. Removal needs none — the bookmark visibly
+  // disappearing is the feedback. Storage is synchronous, so this is a
+  // confirmation and not a loading state.
+  if (favourited) {
+    button.classList.add("is-just-added");
+    const timer = window.setTimeout(() => {
+      transientTimers.delete(button);
+      button.classList.remove("is-just-added");
+    }, TRANSIENT_MS);
+    transientTimers.set(button, timer);
+  }
+}
+
+/**
+ * Reflect stored state onto every rendered control. The site is pre-rendered,
+ * so every card ships from the CDN unfavourited and is corrected here — kept
+ * early and cheap (one storage read, one attribute per button) to keep the
+ * flash of unfavourited bookmarks short.
+ */
+function hydrate() {
+  const buttons = document.querySelectorAll(BUTTON_SELECTOR);
+  if (buttons.length === 0) return;
+
+  for (const button of buttons) {
+    const code = button.dataset.sessionCode;
+    // A stored code that isn't in this build's schedule — a cancelled session,
+    // or a stale entry — simply has no button here. It is skipped, not
+    // deleted: the schedule regenerates from Pretalx and a session can
+    // plausibly disappear and come back (§4.3).
+    applyState(button, code ? has(code) : false);
+  }
+}
+
+function init() {
+  hydrate();
+
+  // Every bookmark sits inside a card that is itself a link to the session
+  // page, so the click must be stopped dead: without both calls, favouriting
+  // navigates away every single time.
+  document.addEventListener("click", (event) => {
+    const button = event.target.closest?.(BUTTON_SELECTOR);
+    if (!button) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    onToggle(button);
+  });
+
+  // Clear any pending confirmation before the page goes away, so a timer never
+  // fires against a detached element.
+  window.addEventListener("pagehide", () => {
+    for (const button of document.querySelectorAll(BUTTON_SELECTOR)) {
+      clearTransient(button);
+    }
+  });
+}
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", init, { once: true });
+} else {
+  init();
+}

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1113,15 +1113,21 @@ ul.sub-menu {
 
 /* Space for the favourite bookmark, reserved in Phase 1 and filled in Phase
    3a. Beside the top row only, so it reserves width for the time and title
-   without pushing the bottom row in. Negative margins pull it level with the
-   time's cap height and out to the card's padding edge, where a 44px tap
-   target belongs; the geometry is unchanged from when the slot was empty, so
-   dropping the bookmark in causes zero reflow. */
+   without pushing the bottom row in.
+
+   The 44px tap target is deliberately wider than the 24px glyph inside it, so
+   its box has ~10px of slack per side. Sizing the negative margins off that
+   slack rather than off nothing is what makes the glyph's right edge line up
+   with the card's 1rem text padding on the left: -0.625rem pulls the box out
+   by the slack exactly, leaving the glyph itself sitting on the padding edge.
+   The vertical margins keep it level with the time's cap height. Card
+   geometry is unchanged from when the slot was empty, so the bookmark still
+   causes zero reflow. */
 .agenda-card__star-slot {
   @apply flex-shrink-0;
   width: 44px;
   height: 44px;
-  margin: -0.375rem -0.5rem -0.5rem 0;
+  margin: -0.375rem -0.625rem -0.5rem 0;
 }
 
 /* ---------------------------------------------------------------------------
@@ -1293,24 +1299,89 @@ ul.sub-menu {
    that is always there. Hover-reveal on it only applies where a pointer
    actually exists, which the (hover: hover) block above already scopes. */
 
-/* Desktop grid: overlaid on the card, never in its flow. The card's height is
-   computed from the session's duration and is not free to grow, so a control
-   in the flow would reflow it or clip the title - the 30-minute Saturday card
-   is the tight case. Positioned inside .schedule-event so it still inherits
-   the track's text colour. */
-.schedule-event .bookmark-btn--card {
-  @apply absolute z-10;
-  /* Pulled out over the card's padding so the 44px target sits in the corner
-     without the glyph drifting away from it. */
-  top: -0.25rem;
-  right: -0.25rem;
+/* Desktop grid: the time and the bookmark share the card's top row, in normal
+   flow. The card's height comes from the session's duration and is not free to
+   grow, so the 44px target must not set that row's height - it is allowed to
+   overflow its line box instead, which keeps the row as tall as the time text
+   alone and leaves the shortest cards (a 30-minute Saturday session) exactly
+   as tall as they were. */
+.schedule-event-top {
+  @apply flex items-start justify-between gap-2 w-full;
+  /* The row is only as tall as the time text; the taller button overflows it
+     rather than pushing the title down. */
+  min-height: 0;
 }
 
-/* Titles run under the overlaid control, so the first line reserves room for
-   it. Only where a bookmark is actually rendered - breaks and the
-   not-yet-announced placeholder keep the full width. */
-.schedule-event:has(.bookmark-btn) .schedule-event-topic {
-  padding-right: 1.5rem;
+.schedule-event .bookmark-btn--card {
+  /* Negative margins absorb the tap target's slack around the 24px glyph, so
+     the glyph's right edge lines up with the card's 1rem text padding and the
+     button claims no vertical space in the row. Same reasoning as the agenda
+     card's star slot. */
+  margin-top: -0.625rem;
+  margin-right: -0.625rem;
+  margin-bottom: -0.625rem;
+}
+
+/* Pinned: the welcomes, the keynotes and the close. Everyone is at these, so
+   the bookmark states that rather than offering a choice - filled, always
+   visible, and not interactive. Rendered as a <span>, so there is no focus
+   ring or pointer to suppress; it just needs to always show the filled glyph
+   and never respond to hover. */
+.bookmark-btn--pinned {
+  @apply cursor-default;
+}
+
+.bookmark-btn--pinned .bookmark-btn__glyph--border,
+.bookmark-btn--pinned .bookmark-btn__glyph--add,
+.bookmark-btn--pinned .bookmark-btn__glyph--added,
+.schedule-event:hover .bookmark-btn--pinned .bookmark-btn__glyph--add,
+.agenda-card:hover .bookmark-btn--pinned .bookmark-btn__glyph--add {
+  display: none;
+}
+
+.bookmark-btn--pinned .bookmark-btn__glyph--filled {
+  display: inline;
+}
+
+/* Never hover-reveal a pinned bookmark: it is not a control, so hiding it
+   until hover would misrepresent it as one and hide the information. */
+@media (hover: hover) {
+  .bookmark-btn--card.bookmark-btn--pinned {
+    opacity: 1;
+  }
+}
+
+/* Ticketed separately, so favouriting is switched off for now. Kept visible
+   and muted rather than removed: the session genuinely has a control, it is
+   just unavailable, and hiding it entirely would read as an oversight next to
+   neighbouring cards that have one. Deliberately a placeholder - the intended
+   treatment reflects registration rather than simply disabling. */
+.bookmark-btn--disabled {
+  @apply cursor-not-allowed;
+  opacity: 0.4;
+}
+
+/* A disabled control gets no hover intent - it would promise an action that
+   will not happen. It keeps the plain outline in every state. */
+.bookmark-btn--disabled .bookmark-btn__glyph--add,
+.bookmark-btn--disabled .bookmark-btn__glyph--added,
+.bookmark-btn--disabled .bookmark-btn__glyph--filled,
+.schedule-event:hover .bookmark-btn--disabled .bookmark-btn__glyph--add,
+.agenda-card:hover .bookmark-btn--disabled .bookmark-btn__glyph--add {
+  display: none;
+}
+
+.bookmark-btn--disabled .bookmark-btn__glyph--border {
+  display: inline;
+}
+
+/* Still revealed on card hover like any other card bookmark, so its presence
+   and its unavailability are both discoverable. */
+@media (hover: hover) {
+  .schedule-event:hover .bookmark-btn--card.bookmark-btn--disabled,
+  .agenda-card:hover .bookmark-btn--card.bookmark-btn--disabled {
+    opacity: 0.4;
+  }
 }
 
 /* Session detail page: always visible, no hover reveal - there is one control

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1334,12 +1334,15 @@ ul.sub-menu {
 .bookmark-btn--pinned .bookmark-btn__glyph--border,
 .bookmark-btn--pinned .bookmark-btn__glyph--add,
 .bookmark-btn--pinned .bookmark-btn__glyph--added,
+.bookmark-btn--pinned .bookmark-btn__glyph--filled,
 .schedule-event:hover .bookmark-btn--pinned .bookmark-btn__glyph--add,
 .agenda-card:hover .bookmark-btn--pinned .bookmark-btn__glyph--add {
   display: none;
 }
 
-.bookmark-btn--pinned .bookmark-btn__glyph--filled {
+/* bookmark_heart, shown only when pinned - a different shape from the plain
+   filled bookmark an attendee saves for themselves. */
+.bookmark-btn--pinned .bookmark-btn__glyph--heart {
   display: inline;
 }
 
@@ -1351,38 +1354,9 @@ ul.sub-menu {
   }
 }
 
-/* Ticketed separately, so favouriting is switched off for now. Kept visible
-   and muted rather than removed: the session genuinely has a control, it is
-   just unavailable, and hiding it entirely would read as an oversight next to
-   neighbouring cards that have one. Deliberately a placeholder - the intended
-   treatment reflects registration rather than simply disabling. */
-.bookmark-btn--disabled {
-  @apply cursor-not-allowed;
-  opacity: 0.4;
-}
-
-/* A disabled control gets no hover intent - it would promise an action that
-   will not happen. It keeps the plain outline in every state. */
-.bookmark-btn--disabled .bookmark-btn__glyph--add,
-.bookmark-btn--disabled .bookmark-btn__glyph--added,
-.bookmark-btn--disabled .bookmark-btn__glyph--filled,
-.schedule-event:hover .bookmark-btn--disabled .bookmark-btn__glyph--add,
-.agenda-card:hover .bookmark-btn--disabled .bookmark-btn__glyph--add {
-  display: none;
-}
-
-.bookmark-btn--disabled .bookmark-btn__glyph--border {
-  display: inline;
-}
-
-/* Still revealed on card hover like any other card bookmark, so its presence
-   and its unavailability are both discoverable. */
-@media (hover: hover) {
-  .schedule-event:hover .bookmark-btn--card.bookmark-btn--disabled,
-  .agenda-card:hover .bookmark-btn--card.bookmark-btn--disabled {
-    opacity: 0.4;
-  }
-}
+/* Sessions ticketed separately render no bookmark at all, so there is no
+   disabled state to style. See BookmarkButton.astro - a greyed-out control
+   still reads as a control, and Wednesday is workshops end to end. */
 
 /* Session detail page: always visible, no hover reveal - there is one control
    and it is not competing with a dense grid, so a reveal would only hide it.

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1111,17 +1111,220 @@ ul.sub-menu {
   height: 1em;
 }
 
-/* Reserved space for the Phase 3 favourite star. Deliberately empty rather
-   than a visible-but-dead star, which invites tapping and disappoints.
-   Beside the top row only, so it reserves width for the time and title
+/* Space for the favourite bookmark, reserved in Phase 1 and filled in Phase
+   3a. Beside the top row only, so it reserves width for the time and title
    without pushing the bottom row in. Negative margins pull it level with the
    time's cap height and out to the card's padding edge, where a 44px tap
-   target belongs; dropping a star in causes zero reflow. */
+   target belongs; the geometry is unchanged from when the slot was empty, so
+   dropping the bookmark in causes zero reflow. */
 .agenda-card__star-slot {
   @apply flex-shrink-0;
   width: 44px;
   height: 44px;
   margin: -0.375rem -0.5rem -0.5rem 0;
+}
+
+/* ---------------------------------------------------------------------------
+   Favourite bookmark - .claude/plans/phase-3a-local-favourites.md §3
+
+   Four Material Symbols glyphs all ship in the markup; this picks one. The
+   states differ by shape - outline, add, added, filled - never by colour, so
+   they survive both a colour-blind reader and a track whose background is
+   nearly the icon's colour.
+
+   Nothing here sets a colour. The SVG is fill="currentColor" and the cards set
+   `color: <track text colour>` on themselves, so the glyph inherits a colour
+   already chosen to read against that track. If it looks right on one track
+   and wrong on another, the button has fallen out of that inheritance chain -
+   it is not a contrast problem.
+   ------------------------------------------------------------------------ */
+.bookmark-btn {
+  @apply inline-flex items-center justify-center flex-shrink-0;
+  @apply cursor-pointer bg-transparent border-0 p-0;
+  /* WCAG 2.5.8 / iOS HIG minimum tap target, larger than the glyph itself. */
+  width: 44px;
+  height: 44px;
+  color: inherit;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.bookmark-btn__icon {
+  @apply block pointer-events-none;
+  width: 24px;
+  height: 24px;
+  transition: transform 150ms ease-out;
+}
+
+/* Exactly one glyph is visible at a time. Default: the unfavourited outline. */
+.bookmark-btn__glyph {
+  display: none;
+}
+
+.bookmark-btn__glyph--border {
+  display: inline;
+}
+
+/* Hover and focus-visible both read as "add this" intent. focus-visible is not
+   optional: without it a keyboard user tabs onto a control that is invisible on
+   the hover-reveal surfaces.
+
+   Hovering the card counts, not just the glyph itself: the card hover is what
+   reveals the control, so revealing a bare outline there and only switching to
+   bookmark_add once the pointer lands on the 44px target would show the wrong
+   thing for the whole approach. The reveal should say what will happen. */
+@media (hover: hover) {
+  .bookmark-btn:hover .bookmark-btn__glyph--border,
+  .schedule-event:hover .bookmark-btn--card .bookmark-btn__glyph--border,
+  .agenda-card:hover .bookmark-btn--card .bookmark-btn__glyph--border {
+    display: none;
+  }
+
+  .bookmark-btn:hover .bookmark-btn__glyph--add,
+  .schedule-event:hover .bookmark-btn--card .bookmark-btn__glyph--add,
+  .agenda-card:hover .bookmark-btn--card .bookmark-btn__glyph--add {
+    display: inline;
+  }
+}
+
+.bookmark-btn:focus-visible .bookmark-btn__glyph--border {
+  display: none;
+}
+
+.bookmark-btn:focus-visible .bookmark-btn__glyph--add {
+  display: inline;
+}
+
+.bookmark-btn:focus-visible {
+  @apply outline-2 outline-offset-2 outline-current;
+  outline-style: solid;
+  border-radius: 0.5rem;
+}
+
+/* Favourited: the filled bookmark wins over every unfavourited glyph,
+   including the card-hover and focus states above, which are more specific
+   than a bare .bookmark-btn:hover and so have to be named here. */
+.bookmark-btn[aria-pressed="true"] .bookmark-btn__glyph--border,
+.bookmark-btn[aria-pressed="true"] .bookmark-btn__glyph--add,
+.schedule-event:hover .bookmark-btn[aria-pressed="true"] .bookmark-btn__glyph--add,
+.agenda-card:hover .bookmark-btn[aria-pressed="true"] .bookmark-btn__glyph--add,
+.bookmark-btn[aria-pressed="true"]:hover .bookmark-btn__glyph--add,
+.bookmark-btn[aria-pressed="true"]:focus-visible .bookmark-btn__glyph--add {
+  display: none;
+}
+
+.bookmark-btn[aria-pressed="true"] .bookmark-btn__glyph--filled {
+  display: inline;
+}
+
+/* The transient confirmation, ~1.2s after a deliberate tap. Applied by script
+   and never by hydration - replaying this on load for every saved session
+   would be absurd. */
+.bookmark-btn.is-just-added .bookmark-btn__glyph--border,
+.bookmark-btn.is-just-added .bookmark-btn__glyph--add,
+.bookmark-btn.is-just-added .bookmark-btn__glyph--filled,
+.schedule-event:hover .bookmark-btn.is-just-added .bookmark-btn__glyph--add,
+.agenda-card:hover .bookmark-btn.is-just-added .bookmark-btn__glyph--add,
+.bookmark-btn.is-just-added:hover .bookmark-btn__glyph--add,
+.bookmark-btn.is-just-added:focus-visible .bookmark-btn__glyph--add {
+  display: none;
+}
+
+.bookmark-btn.is-just-added .bookmark-btn__glyph--added {
+  display: inline;
+}
+
+.bookmark-btn.is-just-added .bookmark-btn__icon {
+  animation: bookmark-pop 300ms ease-out;
+}
+
+@keyframes bookmark-pop {
+  0% {
+    transform: scale(1);
+  }
+  40% {
+    transform: scale(1.25);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+/* The state change is information; the movement is decoration. Suppress only
+   the decoration - the glyph still swaps. */
+@media (prefers-reduced-motion: reduce) {
+  .bookmark-btn__icon {
+    transition: none;
+  }
+
+  .bookmark-btn.is-just-added .bookmark-btn__icon {
+    animation: none;
+  }
+}
+
+/* Dense surfaces - the agenda list and the desktop grid - hide the control
+   until hover on pointer devices, where the reveal is itself the affordance.
+   On touch there is no hover to reveal it, so it must be present from the
+   start: `(hover: hover)` is the right query rather than a width breakpoint,
+   since the distinction is input type and a touchscreen laptop gets a width
+   query wrong. A favourited or focused bookmark always shows. */
+@media (hover: hover) {
+  .bookmark-btn--card {
+    opacity: 0;
+    transition: opacity 150ms ease-out;
+  }
+
+  .schedule-event:hover .bookmark-btn--card,
+  .agenda-card:hover .bookmark-btn--card,
+  .bookmark-btn--card:hover,
+  .bookmark-btn--card:focus-visible,
+  .bookmark-btn--card[aria-pressed="true"],
+  .bookmark-btn--card.is-just-added {
+    opacity: 1;
+  }
+}
+
+@media (hover: hover) and (prefers-reduced-motion: reduce) {
+  .bookmark-btn--card {
+    transition: none;
+  }
+}
+
+/* The mobile agenda card is touch-first, and its slot was sized for a control
+   that is always there. Hover-reveal on it only applies where a pointer
+   actually exists, which the (hover: hover) block above already scopes. */
+
+/* Desktop grid: overlaid on the card, never in its flow. The card's height is
+   computed from the session's duration and is not free to grow, so a control
+   in the flow would reflow it or clip the title - the 30-minute Saturday card
+   is the tight case. Positioned inside .schedule-event so it still inherits
+   the track's text colour. */
+.schedule-event .bookmark-btn--card {
+  @apply absolute z-10;
+  /* Pulled out over the card's padding so the 44px target sits in the corner
+     without the glyph drifting away from it. */
+  top: -0.25rem;
+  right: -0.25rem;
+}
+
+/* Titles run under the overlaid control, so the first line reserves room for
+   it. Only where a bookmark is actually rendered - breaks and the
+   not-yet-announced placeholder keep the full width. */
+.schedule-event:has(.bookmark-btn) .schedule-event-topic {
+  padding-right: 1.5rem;
+}
+
+/* Session detail page: always visible, no hover reveal - there is one control
+   and it is not competing with a dense grid, so a reveal would only hide it.
+   Larger, since this page has the room. This page carries no track colour, so
+   currentColor resolves to ordinary page text, which is correct. */
+.bookmark-btn--detail {
+  width: 48px;
+  height: 48px;
+}
+
+.bookmark-btn--detail .bookmark-btn__icon {
+  width: 32px;
+  height: 32px;
 }
 
 /* Breaks: full width, dashed, no room label - the grid's colSpan is

--- a/src/utils/favourites-config.ts
+++ b/src/utils/favourites-config.ts
@@ -1,0 +1,61 @@
+// Curated exceptions to ordinary favouriting.
+//
+// Both lists are hardcoded by session code rather than derived from session
+// type, because neither rule actually follows from type. "Always favourited"
+// is not all plenaries - the lightning talks and the opening keynote talks are
+// plenaries an attendee may well want to opt out of. And "cannot be
+// favourited" is a registration question, not a scheduling one.
+//
+// Codes are stable Pretalx identifiers, so this list survives a retitle. It
+// does not survive a session being recreated upstream, which is the known cost
+// of hardcoding; a code that no longer exists is simply inert.
+
+/**
+ * Sessions everybody is at. These render as favourited and cannot be
+ * unfavourited - the bookmark is shown filled and inert, as a statement rather
+ * than a control.
+ *
+ * Conference welcome for each day, the keynotes now that they are public, and
+ * the closing address.
+ */
+export const ALWAYS_FAVOURITED = new Set<string>([
+  // Conference welcome - Thursday, Friday, Saturday
+  "3FQZVE",
+  "VQD3SG",
+  "9PXVYP",
+
+  // Keynotes
+  "NDWRBS", // Thursday - 30 to 70 PRs a day
+  "BYLBNB", // Friday - Why Australians don't trust AI
+  "X79GWF", // Saturday - The Care of Software
+
+  // Conference close
+  "TGQGWT", // Closing address
+]);
+
+/**
+ * Sessions ticketed separately from the conference. Favouriting is disabled on
+ * these for now: an attendee who has not registered would otherwise save a
+ * session they cannot attend, and one who has does not need to.
+ *
+ * This is a placeholder treatment. The intended UX is a control that reflects
+ * registration rather than one that is simply switched off.
+ */
+export const NOT_FAVOURITABLE = new Set<string>([
+  // Workshops. Sprints belong here in principle, but they are not sessions -
+  // they live on their own hand-built page and are included with a contributor
+  // ticket - so there is no card to disable and nothing to list.
+  "H33RW8", // Build a cross-platform GUI app with Python
+  "GGCEE9", // Typed Python: from Zero to Hero
+  "PZPG8U", // Building Durable AI Agents with AWS Strands, MCP, and Temporal
+]);
+
+/** Is this session pinned as always-favourited? */
+export function isAlwaysFavourited(code: string): boolean {
+  return ALWAYS_FAVOURITED.has(code);
+}
+
+/** Is favouriting disabled for this session? */
+export function isNotFavouritable(code: string): boolean {
+  return NOT_FAVOURITABLE.has(code);
+}


### PR DESCRIPTION
Implements [Phase 3a](.claude/plans/phase-3a-local-favourites.md) of the schedule work: attendees can favourite sessions, and those favourites persist across page loads and browser restarts on that device.

**Front-end only.** No API, no JWT, no auth, no sync, no network call of any kind — Phase 3b adds sync on top of this storage shape.

## What's here

- `src/scripts/favourites-storage.js` — read/write/toggle/has, defensive parsing, in-memory fallback
- `src/scripts/favourites.js` — one delegated click listener, hydration pass
- `src/components/schedule/BookmarkButton.astro` — five inline Material Symbols glyphs, `data-session-code` on the button
- `src/utils/favourites-config.ts` — the two curated lists
- Wired into the mobile agenda card, the desktop grid card and the session detail page

Storage is session code → ISO timestamp under `pyconau2026.favourites`, plus a `migratedToAccount` flag reserved for 3b's merge. Nothing else — a favourite is a reference into the schedule, not a snapshot of it, so it can't go stale when the schedule flexes.

## Curated exceptions

**Pinned** (welcomes, keynotes, closing address) render `bookmark_heart` and can't be unfavourited — a `<span role="img">` rather than a disabled button, since there's no action to offer, but still announced, because "everyone's at this one" is information a screen reader user needs too. Thursday, Friday and Saturday only.

**Workshops** render no bookmark at all. A greyed-out control still reads as a control, and Wednesday is workshops end to end. The card's existing "Separate registration" note carries the information already. Placeholder — the intended UX reflects registration rather than omitting the control.

Both lists are keyed on session code rather than derived from session type, because neither rule follows from type: not all plenaries are unmissable, and separate registration is a ticketing question. Codes survive a retitle but not a session being recreated upstream.

## The fiddly parts

- Every bookmark sits inside a card that's a link, so the handler `preventDefault()`s and `stopPropagation()`s. Without both, favouriting navigates away every time.
- Hydration lands on the filled state directly, never replaying the ~1.2s confirmation — otherwise every saved session animates on every page load.
- That confirmation is interruptible: a second tap inside the window unfavourites immediately rather than queueing behind the timeout.
- Hover-reveal also triggers on `:focus-visible`, or a keyboard user tabs onto an invisible control. `(hover: hover)` scopes by input type; a width query gets touchscreen laptops wrong.
- Every glyph is `fill="currentColor"` and nothing takes a colour — the cards already set `color: <track text colour>`, so the icon inherits it on every track including any added later.
- Storage reads are defensive: unparseable JSON or an unknown version resolves to empty rather than throwing on load and taking the schedule down.

## Verification

Driven with a real browser (Playwright, installed outside the repo — no new dependency here). 47 checks against the plan's §10 acceptance criteria, all passing.

Two results measured rather than assumed:

- **Grid geometry at 1024px and 1440px is byte-identical to `main`** — every card position, size and title. Same for the mobile agenda, apart from an intended 2px padding shift. The reserved slot from Phase 1 needed zero layout change to fill.
- **`currentColor` inheritance checked on all six track backgrounds across all five days**, including `education` (`#bdf462` → dark) and `research-software-engineering` (`#511FE5` → white). `education` doesn't appear on Saturday, so a single-day check would have missed it.

Also covered: corrupt and unknown-version storage, `localStorage` disabled entirely, `prefers-reduced-motion`, keyboard toggle via space and enter, and that favouriting makes no network request.

Not verified mechanically: the actual VoiceOver announcement. The ARIA plumbing is right — `aria-pressed`, session-naming `aria-label`, `aria-hidden` glyph — but real screen reader behaviour needs a human.

Per the repo's convention I didn't run `npm run build`; everything was checked against the dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)