### PR TITLE
Re-read favourites when a page is restored from bfcache

### DIFF
--- a/src/scripts/favourites.js
+++ b/src/scripts/favourites.js
@@ -86,6 +86,11 @@ function hydrate() {
     // no aria-pressed to correct. Leave them exactly as they came.
     if (button.dataset.pinned === "true") continue;
 
+    // Drop any confirmation left over from before — on a bfcache restore the
+    // class can come back with no timer behind it, and hydration settles
+    // straight to the stored state either way (§9).
+    clearTransient(button);
+
     const code = button.dataset.sessionCode;
     // A stored code that isn't in this build's schedule — a cancelled session,
     // or a stale entry — simply has no button here. It is skipped, not
@@ -97,6 +102,22 @@ function hydrate() {
 
 function init() {
   hydrate();
+
+  // A page restored from the back/forward cache does not re-run this script:
+  // the DOM comes back frozen exactly as it was left, so a session favourited
+  // on its own page after leaving the schedule reads as unfavourited until a
+  // manual refresh. event.persisted marks that restore, and re-hydrating is
+  // cheap enough to just do again.
+  window.addEventListener("pageshow", (event) => {
+    if (event.persisted) hydrate();
+  });
+
+  // The same staleness without bfcache: a second tab, or a mobile browser that
+  // discarded and rebuilt this one. Re-reading on the way back to visible
+  // catches both.
+  document.addEventListener("visibilitychange", () => {
+    if (document.visibilityState === "visible") hydrate();
+  });
 
   // Every bookmark sits inside a card that is itself a link to the session
   // page, so the click must be stopped dead: without both calls, favouriting


### PR DESCRIPTION
## The bug

Reported by an attendee:

> If I mark a talk on and then do a Back navigation, it doesn't show up until a page refresh.

## Cause

The back/forward cache. The site has no view transitions, so favourites hydrate exactly once on `DOMContentLoaded`:

1. Schedule page loads, `hydrate()` sets `aria-pressed` from localStorage.
2. User opens a talk and bookmarks it there. The schedule page is frozen into bfcache **with its DOM as it was** — that button still `aria-pressed="false"`.
3. Back restores the frozen page. No `DOMContentLoaded`, no script re-run, so `hydrate()` never fires again.
4. Refresh is a real load, so it corrects — which is exactly the shape of the report.

## Fix

- Re-hydrate on `pageshow` when `event.persisted` marks a bfcache restore. This is the one that fixes the reported flow.
- Re-hydrate on `visibilitychange` → visible, for the same staleness without bfcache: a second tab, or a mobile browser that discarded and rebuilt this one.
- `hydrate()` now clears any pending confirmation itself instead of relying on the `pagehide` cleanup, so a button frozen mid-confirmation can't come back wearing `is-just-added` with no timer behind it.

Re-hydrating is one storage read plus one attribute per button, so running it again on restore is cheap. Pinned bookmarks are still skipped untouched.

## Testing

Chrome for Testing **refuses to bfcache under automation** — a probe stamping the JS heap before navigating reported `page re-parsed` after Back, with the unfixed code passing. So a scripted Back navigation proves nothing here.

Verified instead by reproducing the state a restore produces — DOM frozen stale while localStorage moved on — then firing the real `pageshow{persisted:true}` event against both versions:

| | unfixed | fixed |
|---|---|---|
| stale state reproduced | yes | yes |
| `pageshow` re-hydrates | **no — fails** | yes |
| `visibilitychange` re-hydrates | yes | yes |

The control fails exactly where predicted and passes with the change.

**Worth confirming on a real phone before merge:** bookmark from a talk page, hit Back. The one link not exercised end to end is Chrome actually electing to bfcache the schedule page. The diagnosis matches the report's signature (broken on Back, fine on refresh), but that part is inference rather than something observed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)