### PR TITLE
Add a Speakers Guide to the attendee guide

### DIFF
--- a/src/content/attend/speakers-guide.md
+++ b/src/content/attend/speakers-guide.md
@@ -1,0 +1,200 @@
+> Hello Speakers\!
+> 
+> Here is some information that you might find useful.
+> 
+> This covers quite a few topics, so please take a moment to read it closely.
+> 
+> If you’re left with any questions after you have read this information, please contact us at [program@pycon.org.au](mailto:program@pycon.org.au) and we will do our best to help you out.
+> 
+> -- PyCon AU 2026 Program Chair
+
+[Things all presenters should know](#things-all-presenters-should-know)
+
+* [Talk Duration](#talk-duration)  
+* [Slide Tips](#slide-tips)  
+* [Conduct and Expectations](#conduct-and-expectations)  
+* [Content warnings](#content-warnings)  
+* [Talk Recording](#talk-recording)  
+* [Your Published Talk Details](#your-published-talk-details)  
+* [What To Do If Something Comes Up](#what-to-do-if-something-comes-up)
+
+[Presenting](#presenting)
+
+* [What should I wear?](#what-should-i-wear)  
+* [Using Generative AI on slides](#using-generative-ai-on-slides)  
+* [Display Resolution](#display-resolution)  
+* [Video Connections](#video-connections)  
+* [Testing Your Laptop](#testing-your-laptop)  
+* [Arrive Early](#arrive-early)
+
+## TLDR
+
+* Your slides will be presented on a 1080p screen (1920 x 1080\) via HDMI.  
+* You will be presenting on a brightly illuminated LED media wall. A bright white background on your slides will ‘flash bang’ your audience, and small fonts will look even worse than usual. Use. Big. Text.  
+* Please respect the 30 minutes allotted to your talk, just as speakers before and after will respect your time too.  
+* Consider your use of AI thoughtfully, and declare transparently where you use AI. We will ask for your AI declaration when you arrive at the conference.  
+* If you are not attending the full Thursday-Saturday conference, please make sure you have collected your lanyard **early** on the day of your talk (well before 9am).  
+* Please arrive in your scheduled room **before the end of the meal break preceding your talk** and introduce yourself to your session chair. Your session chair needs to know you are present and ready to go for that block.  
+* If you miss registration or session chair ‘check-in’s we may assume you are not at PyCon AU and your talk may be cancelled due to absence. Please communicate early and often if we need to accommodate exceptions.
+
+## Things all presenters should know
+
+### Talk Duration
+
+**All talks run for half an hour (30 minutes)\*, including questions.**
+
+It is your choice whether to allow time for questions inside your time slot. Often, speakers who choose to take questions will allow 5 minutes for questions.
+
+However, you can decide how you would like to handle questions about your talk. By default, Session Chairs will assume you are **not** taking questions. Please tell your Session Chair what your preferences are.
+
+You have two choices for taking questions for your talk:
+
+* **No questions** \- (default) you can use the whole 30 minutes for your talk. If people have questions they can find you afterwards.  
+* **Curated questions** \- your Session Chair will stand next to the microphone and moderate questions (e.g. by stepping in if someone makes a comment instead of asking a question), including passing the microphone to audience members.
+
+Your Session Chair will sit in the front row and give you time warning cards at 5, 2, and 1 minutes remaining, and STOP when you have hit your time (e.g. at 25 minutes if you want 5 minutes for questions). Please speak with your Session Chair before your talk about any preferences you have.
+
+There are 5 minutes between talks for changeover (if you have presented at PyCon AU before, this is tighter than previous years). **Please respect this time limit**. Once your slot is over, please collect your things and continue any conversations in the hallway, in order to give the next speaker an equal chance to prepare.
+
+### Slide Tips
+
+There is no official slide deck, brand kit, or approval process for your slides. You are broadly free to pick whatever presentation software, design and techniques that work for you. As long as it works to (reliably) produce a 1080p output over HDMI.
+
+Here are some suggestions for slide design that will help you avoid a few common disappointing situations that presenters can face. (We thank previous PyCon AU organisers for this helpful list).
+
+* **Avoid using small fonts or densely pack small details into your slides/talk**.  1080p is the target resolution, but the LED displays used at the event this year will slightly rescale content \- which means tiny details will be hard to read, especially from a distance.
+
+* **Ensure that text isn’t too close to the borders** or sides of your slides  
+  * Projectors & screens have a tendency to cut the sides of your slides\!  
+    * Avoid highly indented bullet points  
+      * It’s a sign you’re overloading the slide.  
+      * With too much information.  
+        * Which can get frustrating  
+* Ensure that text is large enough to be readable at a distance (\> 16 point is usually a good guide). If you can read your slide in the thumbnail preview, that is a good sign.  
+* **Use high contrast colour schemes.** White on black is good, blue on white is good, pink on purple is terrible.  
+* **Many people have problems with seeing low contrast colours and images.** Please also try to consider colour-blind people when picking colours.  
+* **Spellcheck your presentation.**
+
+More helpful hints can be found in the Writing Slides section of [VM Brasseur’s Public Speaking Resources](https://github.com/vmbrasseur/Public_Speaking#writing-presentations).
+
+### Conduct and Expectations
+
+Please ensure your talk content and slides comply with our [code of conduct](https://2026.pycon.org.au/conduct/). This includes your own behaviour as well as anything you endorse or encourage.
+
+In particular:
+
+* Don't include content where you attack or pentest conference networks, conference infrastructure, conference processes, or conference attendees, in any way.  
+* If you are talking about past hacks or social engineering, you must have had informed consent for any system or person affected, and you must clearly indicate that this was the case.  
+* If you're not sure whether something you want to present complies with the code of conduct, or you want more information, contact [program@pycon.org.au](mailto:program@pycon.org.au).
+
+Any actions that make attendees feel unwelcome or unsafe fall under the Code of Conduct. There's more information on our [Code of Conduct page](https://2026.pycon.org.au/conduct/).
+
+### Content warnings
+
+If your talk contains content that you think might be sensitive, distressing or traumatic to some people (even if most people will be fine with it) please add a content warning, which you can do by [editing your accepted talk proposal in Pretalx](https://pretalx.com/pycon-au-2026/me/submissions/).
+
+Content warnings aren't a moral judgement on your talk, and they won't restrict who is able to watch it. In fact, the opposite is true—for some of your audience members, if they know something they find distressing is coming up, they'll be better able to handle it than if it's a surprise. That lets them look after their mental health and better engage with and learn from your talk\!
+
+Some examples of content warnings:
+
+* This talk contains extensive discussion of the COVID-19 pandemic throughout.  
+* This talk contains images and brief mentions of bushfires and other natural disasters.
+
+**Content warnings don't exempt you from the code of conduct.** Instead, content warnings are used for things that comply with the code of conduct, but might be distressing to some people.
+
+### Talk Recording
+
+Your talk will be recorded, unless you have opted out of the recording release in your talk proposal form. All recorded talks will be available on the PyCon Australia YouTube channel shortly after the event: [https://www.youtube.com/user/PyConAU](https://www.youtube.com/user/PyConAU).
+
+The talks will also be uploaded to the Linux Australia mirror, at [https://mirror.linux.org.au/pub/pycon-au/](https://mirror.linux.org.au/pub/pycon-au/)
+
+You will (and may have already) received emails from “Next Day Video”, our AV recording team \- we’d love our presenters to review your video before we publish to the wider world.  The team aims to post-produce videos within 24 hours of your presentation (with some exceptions).
+
+We will publish these talks under a [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) licence.
+
+### Your Published Talk Details
+
+Your talk information and biography is [up on our website](https://2026.pycon.org.au/schedule/).
+
+Please take the time to look over your talk entry, and make sure that you are happy with your abstract and biography.
+
+Should you wish to update your biography, profile photo, or abstract, please email any changes to [program@pycon.org.au](mailto:program@pycon.org.au) from the same email address you used to submit your talk, or register for the conference. (We are using this email to contact you right now.)  The presentation title and your name(s) on the official schedule is what will be encoded into the video.
+
+We advise you to send through any changes as soon as possible, ahead of the event, as the organising team will be very busy during the event and will not have time to push website changes outside of egregious errors or emergencies.
+
+### What To Do If Something Comes Up
+
+Sometimes things happen\! Laptops run out of power, slides go missing, transport runs late, family stuff comes up, physical or mental health problems can occur. If anything comes up at any point, please let us know ASAP (e.g. emailing [program@pycon.org.au](mailto:program@pycon.org.au) or speaking with an organiser at the registration desk).
+
+We have an experienced organising team who can help with a broad range of questions, issues, or concerns. The sooner you let us know if there is a problem, the sooner we can work with you to achieve the best possible outcome.
+
+Methods of contact:
+
+* [program@pycon.org.au](mailto:program@pycon.org.au) is regularly monitored before and during the conference  
+* There will be a 24-hour ‘duty phone’ number printed on the back of your badge. If you cannot find a volunteer at the registration desk, or you have an urgent matter after-hours, please call the duty phone. This phone number is only shared with speakers and volunteers. *Please do not post it in discord or online.*  
+* The attendee discord (details to come) is a great informal space with a \#help-desk channel.  
+* The community team can help you with concerns relating to the Code of Conduct. Their contact details will be published on the Code of Conduct page closer to the event.  
+* Less immediate issues can be directed to a Volunteer or Organiser, who will be wearing yellow/lemon coloured lanyards.
+
+In a life threatening emergency, call emergency services (000), and then notify a member of staff (venue, security, or an organiser).
+
+## Presenting
+
+Please note PyCon AU 2026 is an in-person event only. We have not made provisions for remote presentations.
+
+### What should I wear?
+
+PyCon AU has no formal dress code, with the exception that you can’t wear things that violate our Code of Conduct.
+
+Some speakers choose to wear something casual that they feel comfortable in, others choose to wear something formal, yet others choose to wear something attention-grabbing and vivid that expresses who they are. All of those choices are valid and encouraged\!
+
+However, we use over-ear (or DPA) microphones, which are small microphones which fit around your ear, attached to a “beltpack” (which contains a battery and transmitter) via a cable. Because of this:
+
+* You need somewhere to put the “beltpack”, like a belt or a pocket. **This is particularly important if you’re wearing a dress or skirt or an outfit without pockets.**  
+* You need to be able to put on and take off the microphone comfortably in public. (We can route the cable over or under clothing, and you can put the microphone on yourself with our AV team’s guidance, but we don’t have dressing rooms for you to “mic up” in.)
+
+### Using Generative AI on slides
+
+#### **PyCon AU's policy**
+
+If you're new to PyCon AU, it's worth being aware that our community has a lot of different views on the use of generative AI. We do not ban generative AI and in some cases it may be essential to talk. However, excessive or out of context generative AI can distract from an otherwise excellent talk.  
+
+#### **What that means for you**
+
+On the day, we will be collecting a self declaration of whether you use generative AI. We need this to disclose to YouTube whether generative AI was used in the construction of the video. 
+
+#### **If you have questions**
+
+Feel free to reach out to [program@pycon.org.au](mailto:program@pycon.org.au) if you have any questions.
+
+### Display Resolution
+
+We use a **16:9 ratio** on all displays scaled to 1080p resolution (1920 x 1080).
+
+### Video Connections
+
+You will present from your own laptop; we do not collect slides to load onto a lectern computer (if this is not possible, let us know in advance).  You will have a confidence monitor but it will display what is on the projector, not your speaker notes (if you have them, they will display on your laptop screen).
+
+**All** rooms will **only** have HDMI connectors. If you need an adapter to output HDMI, i.e. your laptop only has USB-C ports, **please bring your tested laptop-specific HDMI adapter with you**.  The AV team has spare adapters, but HDMI USB-C adapters are not universal and some laptops only work with their proprietary adapters.  We strongly recommend you bring the power adapter for your device, too.
+
+There will also be an audio connector (3.5mm headphone/mini-jack). If you are intending on playing audio, please let the A/V team know when setting up for your talk so they can test sound levels before you start.
+
+If you have special requirements beyond this, please get in touch in advance with Ryan, the AV team lead, on [ryan@nextdayvideo.com.au](mailto:ryan@nextdayvideo.com.au).
+
+### Testing Your Laptop
+
+**It is recommended that you test your laptop before your talk.** A test setup will be available outside the St Germaine room (behind the escalators) indicated on the map on the back of your conference badge. The registration desk can help direct you as well.
+
+This will be similar to the podium setup, allowing you to plug your laptop in and check that it works for video and audio. The AV office is nearby and an AV volunteer can help you with technical challenges during testing.
+
+### Arrive Early
+
+Please make sure you know when and where your talk is scheduled. Please check the [schedule](https://2026.pycon.org.au/schedule/) to confirm the day, time, and room for which your talk is scheduled.
+
+The schedule may change slightly between now and when the conference starts \- but we'll try and reduce changes as much as possible. If any changes affect you, we will let you know as soon as possible. Again, if you have concerns or need to change something, please contact us at [program@pycon.org.au](mailto:program@pycon.org.au) as soon as possible.
+
+We understand not all presenters can attend all days of the conference. If you intend to register on-the-day of your session, please let us know ahead of time, and then arrive early to collect your badge. We start to worry when speakers haven't yet collected their badge each day, and we'd love to know you're on-site and ready to present\!
+
+**It is essential that you arrive in your talk room in the meal break before your talk** to ‘check in’ with and meet your Session Chair and A/V team. This will give you time to look at the layout of your room, assess the space, etc. For example: after morning tea there is generally a block of three or four sessions \- we ask all three presenters to 'check in' to their room before morning tea ends. And where possible, please stay in or near your room to avoid being distracted elsewhere and missing your talk slot.
+
+If you have not checked into your room in time we may cancel your talk and encourage attendees to see other sessions (to respect their time at PyCon AU).  

--- a/src/pages/attend/speakers-guide.astro
+++ b/src/pages/attend/speakers-guide.astro
@@ -1,0 +1,54 @@
+---
+import AttendNav from "../../components/attend/AttendNav.astro";
+import Footer from "../../components/Footer.astro";
+import Crumb from "../../components/header/Crumb.astro";
+import HeaderBreadcrumbs from "../../components/header/HeaderBreadcrumbs.astro";
+import PageHeader from "../../components/header/PageHeader.astro";
+import PageHeaderTitle from "../../components/header/PageHeaderTitle.astro";
+import Base from "../../layouts/Base.astro";
+// Page body lives in markdown so it can be edited without touching this file.
+import { Content } from "../../content/attend/speakers-guide.md";
+
+export const nav = {
+  order: 7,
+  group: "During PyCon AU",
+  title: "Speakers Guide",
+  image: "/images/attend/bof.jpg",
+};
+---
+
+<Base title="Speakers Guide">
+  <PageHeader dark={true} starColour="violet">
+    <HeaderBreadcrumbs colour="lavender">
+      <Crumb href="/attend/">Attendee Guide</Crumb>
+    </HeaderBreadcrumbs>
+    <PageHeaderTitle textColour="lavender">
+      <h1>Speakers Guide</h1>
+    </PageHeaderTitle>
+  </PageHeader>
+
+  <section>
+    <div class="header-divider header-divider--lavender"></div>
+
+    <div class="bg-stone py-20">
+      <div class="container">
+        <div class="lg:w-[85%] w-full mx-auto">
+          <div
+            class="flex flex-col lg:flex-row justify-between items-start gap-14"
+          >
+            <div class="lg:w-[80%] w-full rich-text">
+              <Content />
+            </div>
+
+            <AttendNav />
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <Footer />
+
+  <!-- Main scripts (will be added in Phase 5) -->
+  <script src="/src/scripts/animations.js"></script>
+</Base>

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -232,6 +232,18 @@ footer ul li a {
   @apply mb-14;
 }
 
+/* Pull-quote style callout, e.g. the welcome note atop the Speakers Guide.
+   Sits on the stone page background, so it reads as a white card. */
+.rich-text blockquote {
+  @apply bg-white rounded-[2.5rem] px-10 py-8 my-10 space-y-4;
+}
+.rich-text blockquote > :first-child {
+  @apply mt-0;
+}
+.rich-text blockquote > :last-child {
+  @apply mb-0;
+}
+
 .rich-text h1 {
   @apply font-serif lg:text-6xl text-5xl font-medium tracking-[-0.02em] leading-[1.3] mt-10;
 }


### PR DESCRIPTION
Adds a Speakers Guide page at `/attend/speakers-guide`, covering talk duration, slide design, conduct expectations, content warnings, recording, and the practicalities of presenting on the day.

## Notes for reviewers

**Markdown-backed body.** The page content lives in `src/content/attend/speakers-guide.md`, imported directly by the `.astro` template, so the guide can be edited without touching markup. This is a plain module import rather than a content collection — the collections in `src/content/config.ts` all back sets of many entries queried with `getCollection`, so a single known page needs no schema. If more markdown-driven guide pages appear later, converting to a collection would be the better shape.

**Sidebar placement.** `nav.order: 7` puts it at the end of the "During PyCon AU" group, ahead of the ungrouped FAQ (order 8). No existing pages needed renumbering. `AttendNav.astro` and the attend index both glob `attend/*.astro` and read the exported `nav`, so the sidebar link and index tile register automatically.

**Blockquote styling.** `.rich-text blockquote` now renders as a white rounded card, for the welcome note at the top of the guide. Nothing on the site styled blockquotes before this, so it establishes a site-wide default — any future `>` quote in a `rich-text` block picks it up. The `2.5rem` radius sits between the large cards (`3.125rem`) and buttons (`1.25rem`).

## Verification

- `astro check`: 0 errors, 0 warnings
- Page returns 200; heading hierarchy renders as one `h1` (from the template) plus 3 `h2`, 13 `h3`, 3 `h4`
- All 15 in-page table-of-contents anchors resolve to real heading IDs, with link text matching each target heading

## Follow-ups, not addressed here

- The index tile reuses `/images/attend/bof.jpg` as a placeholder — needs a real image, or `tile: false` to omit it
- Two leftovers in the source document: a struck-through paragraph about projectors and a stray empty bullet
- `## TLDR` and the three `####` subheadings under "Using Generative AI on slides" have no table-of-contents entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)