### PR TITLE
Adjust talk recording copy in the Speakers Guide

### DIFF
--- a/src/content/attend/speakers-guide.md
+++ b/src/content/attend/speakers-guide.md
@@ -127,15 +127,13 @@ The talks will also be uploaded to the Linux Australia mirror, at [https://mirro
 
 You will (and may have already) received emails from “Next Day Video”, our AV recording team \- we’d love our presenters to review your video before we publish to the wider world.  The team aims to post-produce videos within 24 hours of your presentation (with some exceptions).
 
-We will publish these talks under a [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) licence.
-
 ### Your Published Talk Details
 
 Your talk information and biography is [up on our website](https://2026.pycon.org.au/schedule/).
 
 Please take the time to look over your talk entry, and make sure that you are happy with your abstract and biography.
 
-Should you wish to update your biography, profile photo, or abstract, please email any changes to [program@pycon.org.au](mailto:program@pycon.org.au) from the same email address you used to submit your talk, or register for the conference. (We are using this email to contact you right now.)  The presentation title and your name(s) on the official schedule is what will be encoded into the video.
+Should you wish to update your biography, profile photo, or abstract, please email any changes to [program@pycon.org.au](mailto:program@pycon.org.au) from the same email address you used to submit your talk, or register for the conference. (We used this email to send you this guide.)  The presentation title and your name(s) on the official schedule is what will be encoded into the video.
 
 We advise you to send through any changes as soon as possible, ahead of the event, as the organising team will be very busy during the event and will not have time to push website changes outside of egregious errors or emergencies.
 


### PR DESCRIPTION
Two copy changes to the Talk Recording and Your Published Talk Details sections of the Speakers Guide. Follow-up to #142.

## Changes

**Removed the licence statement.** The CC BY-NC-SA 4.0 line has been dropped from the Talk Recording section. Note this was the document's only mention of talk video licensing — flagging in case speakers are expected to learn the terms somewhere, whether that's back in this guide with different terms, or on the recording release in the proposal form.

**Reworded the email note.** "(We are using this email to contact you right now.)" becomes "(We used this email to send you this guide.)" — the guide is read on the website now, so the present-tense phrasing no longer made sense in context.

**Collapsed a double blank line** left where the licence line was removed. Cosmetic, no rendered difference.

## Verification

- `astro check`: 0 errors, 0 warnings
- Page returns 200; both copy changes present as intended and the old wording is gone
- All 16 in-page contents anchors still resolve to real heading IDs, with link text matching each target heading

## Still outstanding

- Two leftovers in the source document: a struck-through paragraph about projectors and a stray empty bullet
- `## TLDR` and the three `####` under "Using Generative AI on slides" have no contents entries
- Frequently Asked Questions has no `nav.image` and falls back to `/images/about-thumb-3.png`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
