### PR TITLE
travel: update info on King George Square station

### DIFF
--- a/src/pages/attend/around-brisbane.astro
+++ b/src/pages/attend/around-brisbane.astro
@@ -125,7 +125,8 @@ export const nav = {
               <h3 id="buses">Buses</h3>
               <p>
                 Most buses operate via the Queen Street Station precinct
-                (underneath Queen Street pedestrian mall), or from nearby stops
+                (underneath Queen Street pedestrian mall), through King George
+                Square Station, or from nearby stops
                 on Ann and Adelaide Streets. We recommend following your local
                 maps provider's directions, but most stops are within 5-10
                 minutes walk of the Sofitel entrance via Ann St.

--- a/src/pages/attend/travel.astro
+++ b/src/pages/attend/travel.astro
@@ -84,7 +84,8 @@ export const nav = {
               <h3 id="via-bus">via Bus</h3>
               <p>
                 Most bus services will operate via nearby Adelaide, Anne or
-                Queen Streets and are approximately a 5-10 minute walk away from
+                Queen Streets, or King George Square Station, 
+                and are approximately a 5-10 minute walk away from
                 the venue. We recommend using the Ann street entrance noted
                 suggested above.
               </p>


### PR DESCRIPTION
Major works in late 2025 introduced the Adelaide Street Tunnel, which eased congestion on Queen Street into King George Square station.

Slightly closer to venue, it's important to make sure this is mentioned as one of the major bus stops serving the conference.