### PR TITLE
Online ticket type, last minute tickets post, and meta date fix

### DIFF
--- a/src/content/posts/last-minute-tickets.md
+++ b/src/content/posts/last-minute-tickets.md
@@ -1,33 +1,48 @@
 ---
 title: "Last minute tickets, streaming and community discounts!"
 published: 2026-08-11T09:00:00+10:00
-previewText: "There's still time to join us at PyCon AU 2026 — in Brisbane or online."
+previewText: "Today we’ve got new ways for you to attend the conference with last minute tickets!"
 category: "news"
 ---
-PyCon AU 2026 is nearly here, and there's still time to join us! Whether you're coming to Brisbane in person or joining us from your desk, here's what you need to know.
 
-### Last minute tickets
+We can’t wait to see everyone in just two weeks\! Today we’ve got new ways for you to attend the conference with last minute tickets\!
 
-Tickets are still available, and you can register right up until the conference begins. Head to the [tickets page](/tickets/) to register at Professional, Enthusiast or Student levels.
+## Online tickets now available
 
-If you can only make it for part of the week, one day tickets are still available too. A one day ticket includes all talks on that day — both the specialist tracks and the main conference.
+That’s right\! PyCon AU 2026 will be available via live stream for anyone who can’t make it to Brisbane\!  Registration covers access to the full three days of talks including all 6 specialist tracks, along with access to the attendee discord.
 
-### Attend online
+Streaming will be available via PyCon AU’s streaming platform, which means you’ll have to be registered to catch it live.
 
-Can't make it to Brisbane? Talks at PyCon AU 2026 will be available online via live stream. The online ticket is **$120** and includes access to the live streaming service, along with Discord access so you can join the conversation.
+Register your “Online Only” tickets for $120 today.
 
-Your online ticket includes:
+<div class="flex justify-around py-5">
+    <a href="https://pretix.eu/pyconau/2026/" class="btn-arrow no-underline!">
+        <span>Online tickets</span>
+    </a>
+</div>
 
-* 3-day conference stream (Thursday - Saturday)
-* Attendee Discord access
-* Keynotes & lightning talks
+## Community discounts
 
-Note: PyCon AU is not a 'hybrid' conference. Streams may be paused during scheduled breaks, and some activities, networking and exhibition spaces on-site will not be available to remote delegates. Workshops and sprints are not available as a live stream.
+We recognise many people in the PyCon AU community are doing it tough this year. If that's you, we hope this discount voucher helps you to still make it in person.
 
-### Community discounts
+If you’re unemployed or between jobs but can still make it to the conference in person then these vouchers offer a substantial discount on an Enthusiast ticket. We recognise this is an imperfect solution to address affordability but we hope it helps at least some people still make it.
 
-Bringing your team? We'll apply 5% off at checkout when you register 5 or more Professional tickets online, and you'll still receive a GST invoice for your records.
+There’s no formal eligibility to register using these community discounts \- it’s an honour system. 
 
-For larger groups, email [contact@pycon.org.au](mailto:contact@pycon.org.au) to request a group order form and we can help your team register with procurement or accounts payable payment terms.
+* **Enthusiast \- 1 day tickets**: use registration voucher [COMMUNITY-CSBEK8XLWLGUK7YV](https://pretix.eu/pyconau/2026/redeem?voucher=COMMUNITY-CSBEK8XLWLGUK7YV). To attend two days at PyCon AU, please register with a one day ticket for each day you wish to attend.  
+* **Enthusiast \- 3 day ticket**: use registration voucher [COMMUNITY-K4FYQ82YZPWCNHF6](https://pretix.eu/pyconau/2026/redeem?voucher=COMMUNITY-K4FYQ82YZPWCNHF6). This includes Thursday, Friday and Saturday.
 
-We can't wait to see you — in person or online!
+*These tickets are already priced to include all available discounts (and more), and are not intended for teams or professional registration.*
+
+## Last minute registrations
+
+We plan to keep registrations open for as long as possible. Register this week to guarantee your seat at the conference. Registrations after 14 August will be subject to available per-day capacity as we must allocate final catering numbers ahead of the conference.
+
+Register today, and don’t delay\!
+
+<div class="flex justify-around py-10">
+    <a href="https://pretix.eu/pyconau/2026/" class="btn-arrow no-underline!">
+        <span>Register Today</span>
+    </a>
+</div>
+

--- a/src/content/posts/last-minute-tickets.md
+++ b/src/content/posts/last-minute-tickets.md
@@ -1,0 +1,33 @@
+---
+title: "Last minute tickets, streaming and community discounts!"
+published: 2026-08-11T09:00:00+10:00
+previewText: "There's still time to join us at PyCon AU 2026 — in Brisbane or online."
+category: "news"
+---
+PyCon AU 2026 is nearly here, and there's still time to join us! Whether you're coming to Brisbane in person or joining us from your desk, here's what you need to know.
+
+### Last minute tickets
+
+Tickets are still available, and you can register right up until the conference begins. Head to the [tickets page](/tickets/) to register at Professional, Enthusiast or Student levels.
+
+If you can only make it for part of the week, one day tickets are still available too. A one day ticket includes all talks on that day — both the specialist tracks and the main conference.
+
+### Attend online
+
+Can't make it to Brisbane? Talks at PyCon AU 2026 will be available online via live stream. The online ticket is **$120** and includes access to the live streaming service, along with Discord access so you can join the conversation.
+
+Your online ticket includes:
+
+* 3-day conference stream (Thursday - Saturday)
+* Attendee Discord access
+* Keynotes & lightning talks
+
+Note: PyCon AU is not a 'hybrid' conference. Streams may be paused during scheduled breaks, and some activities, networking and exhibition spaces on-site will not be available to remote delegates. Workshops and sprints are not available as a live stream.
+
+### Community discounts
+
+Bringing your team? We'll apply 5% off at checkout when you register 5 or more Professional tickets online, and you'll still receive a GST invoice for your records.
+
+For larger groups, email [contact@pycon.org.au](mailto:contact@pycon.org.au) to request a group order form and we can help your team register with procurement or accounts payable payment terms.
+
+We can't wait to see you — in person or online!

--- a/src/pages/schedule/[code].astro
+++ b/src/pages/schedule/[code].astro
@@ -60,7 +60,17 @@ const displayTrackName = trackName || trackData?.data.title;
 const dateTimeString = start && end ? formatSessionDateTime(start, end) : null;
 
 // Build OG description: title + speakers + track (if not main conf) + date + CTA
-const dateOnly = start ? new Date(start).toLocaleDateString("en-AU", { weekday: "long", day: "numeric", month: "long", year: "numeric" }) : null;
+// timeZone is required: without it the build machine's zone is used, and a
+// morning Brisbane session formats to the previous day on a UTC CI builder.
+const dateOnly = start
+  ? new Date(start).toLocaleDateString("en-AU", {
+      weekday: "long",
+      day: "numeric",
+      month: "long",
+      year: "numeric",
+      timeZone: CONFERENCE_TIMEZONE,
+    })
+  : null;
 const ogDescription = [
   title,
   speakers.length > 0 ? `By ${speakerData.map((s) => s.data.name).join(", ")}` : null,

--- a/src/pages/tickets.astro
+++ b/src/pages/tickets.astro
@@ -246,6 +246,96 @@ import { TICKETING_URL } from "../constants";
               </div>
             </div>
           </div>
+          <div class="fadeInUp bg-[#383838] py-14 lg:col-span-2">
+            <div class="w-full h-full flex flex-col gap-16 justify-between">
+              <div class="space-y-10">
+                <div class="grid lg:grid-cols-2 grid-cols-1">
+                  <div
+                    class="lg:max-w-[426px] w-full lg:px-10 px-5 mx-auto flex lg:flex-row flex-col gap-5 lg:gap-0 justify-between"
+                  >
+                    <div class="space-y-2">
+                      <h3 class="text-lavender font-sans font-semibold text-4xl">
+                        Online
+                      </h3>
+                    </div>
+                    <div class="price lg:text-right lg:hidden">
+                      <span class="text-white text-4xl font-semibold font-sans"
+                        >$120</span
+                      >
+                    </div>
+                  </div>
+                  <div
+                    class="lg:max-w-[426px] w-full lg:px-10 px-5 mx-auto lg:flex hidden justify-end"
+                  >
+                    <div class="price lg:text-right">
+                      <span class="text-white text-4xl font-semibold font-sans"
+                        >$120</span
+                      >
+                    </div>
+                  </div>
+                </div>
+                <div class="grid lg:grid-cols-2 grid-cols-1">
+                  <div
+                    class="space-y-10 lg:max-w-[426px] w-full lg:px-10 px-5 mx-auto"
+                  >
+                    <div class="rich-text">
+                      <p class="text-stone">
+                        Talks at PyCon AU 2026 will be available online via live
+                        stream. The online ticket includes access to the live
+                        streaming service along with discord access so you can
+                        join the conversation.
+                      </p>
+                      <p class="text-stone">
+                        Note: PyCon AU is not a &lsquo;hybrid&rsquo; conference.
+                        Streams may be paused during scheduled breaks, and some
+                        activities, networking and exhibition spaces on-site will
+                        not be available to remote delegates.
+                      </p>
+                    </div>
+                    <div>
+                      <span
+                        class="text-sm text-stone font-sans tracking-[0.01em] block leading-normal pl-[0.85em] -indent-[0.85em]"
+                        ><sup>1</sup> Workshops and sprints are not available as a
+                        live stream.</span
+                      >
+                    </div>
+                  </div>
+                  <div
+                    class="flex flex-col gap-10 justify-between lg:max-w-[426px] w-full lg:px-10 px-5 mx-auto"
+                  >
+                    <div class="space-y-10">
+                      <p class="text-stone">Online tickets include:</p>
+                      <ul class="space-y-5 text-lavender">
+                        <li class="flex items-center gap-3">
+                          <img src="/images/tick-violet.svg" alt="tick" />
+                          <span
+                            >3-day conference stream (Thursday - Saturday) <sup
+                              >1</sup
+                            ></span
+                          >
+                        </li>
+                        <li class="flex items-center gap-3">
+                          <img src="/images/tick-violet.svg" alt="tick" />
+                          <span>Attendee discord access</span>
+                        </li>
+                        <li class="flex items-center gap-3">
+                          <img src="/images/tick-violet.svg" alt="tick" />
+                          <span>Keynotes &amp; lightning talks</span>
+                        </li>
+                      </ul>
+                    </div>
+                    <div class="space-y-7">
+                      <a
+                        href={TICKETING_URL}
+                        class="btn-arrow btn-arrow--violet rounded-[3.125rem]! hover:rounded-none! justify-between py-5!"
+                        ><span>Buy Tickets</span></a
+                      >
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -464,95 +554,6 @@ import { TICKETING_URL } from "../constants";
                       <a
                         href={TICKETING_URL}
                         class="btn-arrow btn-arrow--lime rounded-[3.125rem]! hover:rounded-none! justify-between py-5!"
-                        ><span>Buy Tickets</span></a
-                      >
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div class="fadeInUp bg-[#383838] py-14 lg:col-span-2">
-            <div class="w-full h-full flex flex-col gap-16 justify-between">
-              <div class="space-y-10">
-                <div class="grid lg:grid-cols-2 grid-cols-1">
-                  <div
-                    class="lg:max-w-[426px] w-full lg:px-10 px-5 mx-auto flex lg:flex-row flex-col gap-5 lg:gap-0 justify-between"
-                  >
-                    <div class="space-y-2">
-                      <h3 class="text-lavender font-sans font-semibold text-4xl">
-                        Online
-                      </h3>
-                    </div>
-                    <div class="price lg:text-right lg:hidden">
-                      <span class="text-white text-4xl font-semibold font-sans"
-                        >$120</span
-                      >
-                    </div>
-                  </div>
-                  <div
-                    class="lg:max-w-[426px] w-full lg:px-10 px-5 mx-auto lg:flex hidden justify-end"
-                  >
-                    <div class="price lg:text-right">
-                      <span class="text-white text-4xl font-semibold font-sans"
-                        >$120</span
-                      >
-                    </div>
-                  </div>
-                </div>
-                <div class="grid lg:grid-cols-2 grid-cols-1">
-                  <div
-                    class="space-y-10 lg:max-w-[426px] w-full lg:px-10 px-5 mx-auto"
-                  >
-                    <div class="rich-text">
-                      <p class="text-stone">
-                        Talks at PyCon AU 2026 will be available online via live
-                        stream. The online ticket includes access to the live
-                        streaming service along with discord access so you can
-                        join the conversation.
-                      </p>
-                      <p class="text-stone">
-                        Note: PyCon AU is not a &lsquo;hybrid&rsquo; conference,
-                        and streams will be paused during scheduled meal breaks
-                        etc.
-                      </p>
-                    </div>
-                    <div>
-                      <span
-                        class="text-sm text-stone font-sans tracking-[0.01em] block leading-normal pl-[0.85em] -indent-[0.85em]"
-                        ><sup>1</sup> Workshops and sprints are not available as a
-                        live stream.</span
-                      >
-                    </div>
-                  </div>
-                  <div
-                    class="flex flex-col gap-10 justify-between lg:max-w-[426px] w-full lg:px-10 px-5 mx-auto"
-                  >
-                    <div class="space-y-10">
-                      <p class="text-stone">Online tickets include:</p>
-                      <ul class="space-y-5 text-lavender">
-                        <li class="flex items-center gap-3">
-                          <img src="/images/tick-violet.svg" alt="tick" />
-                          <span
-                            >3-day conference stream (Thursday - Saturday) <sup
-                              >1</sup
-                            ></span
-                          >
-                        </li>
-                        <li class="flex items-center gap-3">
-                          <img src="/images/tick-violet.svg" alt="tick" />
-                          <span>Attendee discord access</span>
-                        </li>
-                        <li class="flex items-center gap-3">
-                          <img src="/images/tick-violet.svg" alt="tick" />
-                          <span>Keynotes &amp; lightning talks</span>
-                        </li>
-                      </ul>
-                    </div>
-                    <div class="space-y-7">
-                      <a
-                        href={TICKETING_URL}
-                        class="btn-arrow btn-arrow--violet rounded-[3.125rem]! hover:rounded-none! justify-between py-5!"
                         ><span>Buy Tickets</span></a
                       >
                     </div>

--- a/src/pages/tickets.astro
+++ b/src/pages/tickets.astro
@@ -472,6 +472,95 @@ import { TICKETING_URL } from "../constants";
               </div>
             </div>
           </div>
+          <div class="fadeInUp bg-[#383838] py-14 lg:col-span-2">
+            <div class="w-full h-full flex flex-col gap-16 justify-between">
+              <div class="space-y-10">
+                <div class="grid lg:grid-cols-2 grid-cols-1">
+                  <div
+                    class="lg:max-w-[426px] w-full lg:px-10 px-5 mx-auto flex lg:flex-row flex-col gap-5 lg:gap-0 justify-between"
+                  >
+                    <div class="space-y-2">
+                      <h3 class="text-lavender font-sans font-semibold text-4xl">
+                        Online
+                      </h3>
+                    </div>
+                    <div class="price lg:text-right lg:hidden">
+                      <span class="text-white text-4xl font-semibold font-sans"
+                        >$120</span
+                      >
+                    </div>
+                  </div>
+                  <div
+                    class="lg:max-w-[426px] w-full lg:px-10 px-5 mx-auto lg:flex hidden justify-end"
+                  >
+                    <div class="price lg:text-right">
+                      <span class="text-white text-4xl font-semibold font-sans"
+                        >$120</span
+                      >
+                    </div>
+                  </div>
+                </div>
+                <div class="grid lg:grid-cols-2 grid-cols-1">
+                  <div
+                    class="space-y-10 lg:max-w-[426px] w-full lg:px-10 px-5 mx-auto"
+                  >
+                    <div class="rich-text">
+                      <p class="text-stone">
+                        Talks at PyCon AU 2026 will be available online via live
+                        stream. The online ticket includes access to the live
+                        streaming service along with discord access so you can
+                        join the conversation.
+                      </p>
+                      <p class="text-stone">
+                        Note: PyCon AU is not a &lsquo;hybrid&rsquo; conference,
+                        and streams will be paused during scheduled meal breaks
+                        etc.
+                      </p>
+                    </div>
+                    <div>
+                      <span
+                        class="text-sm text-stone font-sans tracking-[0.01em] block leading-normal pl-[0.85em] -indent-[0.85em]"
+                        ><sup>1</sup> Workshops and sprints are not available as a
+                        live stream.</span
+                      >
+                    </div>
+                  </div>
+                  <div
+                    class="flex flex-col gap-10 justify-between lg:max-w-[426px] w-full lg:px-10 px-5 mx-auto"
+                  >
+                    <div class="space-y-10">
+                      <p class="text-stone">Online tickets include:</p>
+                      <ul class="space-y-5 text-lavender">
+                        <li class="flex items-center gap-3">
+                          <img src="/images/tick-violet.svg" alt="tick" />
+                          <span
+                            >3-day conference stream (Thursday - Saturday) <sup
+                              >1</sup
+                            ></span
+                          >
+                        </li>
+                        <li class="flex items-center gap-3">
+                          <img src="/images/tick-violet.svg" alt="tick" />
+                          <span>Attendee discord access</span>
+                        </li>
+                        <li class="flex items-center gap-3">
+                          <img src="/images/tick-violet.svg" alt="tick" />
+                          <span>Keynotes &amp; lightning talks</span>
+                        </li>
+                      </ul>
+                    </div>
+                    <div class="space-y-7">
+                      <a
+                        href={TICKETING_URL}
+                        class="btn-arrow btn-arrow--violet rounded-[3.125rem]! hover:rounded-none! justify-between py-5!"
+                        ><span>Buy Tickets</span></a
+                      >
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Adds an **Online** ticket type ($120) as a full-width card on `/tickets`, sitting directly below Professional/Enthusiast.

Also includes:
- New `last-minute-tickets` news post covering online tickets, community discount vouchers and late registration.
- Hotfix: session meta descriptions formatted the date without an explicit `timeZone`, so UTC production builds rendered morning Brisbane sessions one day early (e.g. `/schedule/NDWRBS/` showed Wednesday 26 August instead of Thursday 27).

🤖 Generated with [Claude Code](https://claude.com/claude-code)