### PR TITLE
accommodation: remove Sofitel conference hotel offer

### DIFF
--- a/src/pages/attend/accommodation.astro
+++ b/src/pages/attend/accommodation.astro
@@ -12,7 +12,7 @@ export const nav = {
   order: 0,
   group: "Before PyCon AU",
   title: "Accommodation",
-  image: "/images/attend/accommodation/sofitel.jpg",
+  image: "/images/attend/accommodation/adina-apartment-hotel.jpg",
 };
 ---
 
@@ -34,32 +34,6 @@ export const nav = {
         <div class="lg:w-[85%] mx-auto">
           <div class="fadeInUp">
             <InfoBox />
-          </div>
-
-          <div class="mb-20 fadeInUp">
-            <h2
-              class="fadeInUp text-5xl font-serif font-medium -tracking-[0.02em] mb-10"
-              style="translate: none; rotate: none; scale: none; transform: translate(0px, 0px); opacity: 1;"
-            >
-              Conference Hotel
-            </h2>
-
-            <HotelCard
-              name="Sofitel Brisbane Central"
-              description="Stay at the conference venue for maximum convenience. The Sofitel Brisbane Central has a dedicated offer for PyCon AU delegates."
-              image="/images/attend/accommodation/sofitel.jpg"
-              distance="0 minute walk"
-              link="https://www.idem.events/r/pycon-au-2026"
-              linkText="View Rates"
-              isMain={false}
-            >
-              <p>
-                Stay at the conference venue for maximum convenience. The
-                Sofitel Brisbane Central has a dedicated offer for PyCon AU
-                delegates.
-              </p>
-              <p>Book directly with the hotel before <strong>26 July 2026</strong>.</p>
-            </HotelCard>
           </div>
 
           <div class="fadeInUp">


### PR DESCRIPTION
## Summary

The Sofitel Brisbane Central delegate deal has closed, so this removes the "Conference Hotel" section from the accommodation page.

- Removed the Sofitel `HotelCard`, including the `idem.events` booking link and the "book before 26 July 2026" note, along with the now-empty section heading and wrapper.
- Repointed the page's `nav.image` from `sofitel.jpg` to `adina-apartment-hotel.jpg`, so the nav thumbnail no longer advertises a delisted deal.

The page now opens with the InfoBox followed directly by **Nearby Offers** (Adina, CLLIX, IHG properties). Those listings are untouched.

## Notes

Two things deliberately left alone, happy to change either:

- **Sofitel mentions on the travel and around-brisbane pages remain.** Those describe the Sofitel as the conference venue (Level 2, station entrances, parking, ride-share drop-off) rather than as an accommodation offer, so they're still accurate.
- **`public/images/attend/accommodation/sofitel.jpg` is still on disk**, now unreferenced. Kept since the Sofitel is still the venue and the image may be wanted elsewhere.

## Testing

`npx astro check` passes with 0 errors. The remaining warnings are pre-existing and in unrelated files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)